### PR TITLE
Add checkpointing support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ The Dataflux Dataset for PyTorch lets you connect directly to a GCS bucket as a 
 
 The Dataflux Dataset for PyTorch implements PyTorch’s [dataset primitive](https://pytorch.org/tutorials/beginner/basics/data_tutorial.html) that can be used to efficiently load training data from GCS. The library currently supports [map-style datasets](https://pytorch.org/docs/stable/data.html#map-style-datasets) for random data access patterns.
 
+Furthermore, the Dataflux Dataset for PyTorch provides a checkpointing interface to conveniently save and load checkpoints directly to and from a Google Cloud Storage (GCS) bucket.
+
 Note that the Dataflux Dataset for PyTorch library is in an early preview stage and the team is consistently working on improvements and support for new features.
 
 ## Getting started
@@ -30,8 +32,8 @@ gcloud auth application-default login
 ### Examples
 Before getting started, please make sure you have installed the library and configured authentication following the instructions above.
 
+#### Data Loading
 Dataflux Dataset for PyTorch can be constructed by specifying the project name, bucket name and an optional prefix.
-
 ```python
 from dataflux_pytorch import dataflux_mapstyle_dataset
 
@@ -80,6 +82,32 @@ dataset = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
 for each_object in dataset:
   # each_object is now a Numpy array.
   print(each_object)
+```
+
+#### Checkpointing
+
+The Dataflux Dataset for PyTorch not only supports fast data loading but also allows you to save and load model checkpoints directly to and from a Google Cloud Storage (GCS) bucket.
+
+```python
+import torch
+import torchvision
+
+from dataflux_pytorch import dataflux_checkpoint
+
+ckpt = dataflux_checkpoint.DatafluxCheckpoint(
+  project_name=PROJECT_NAME, bucket_name=BUCKET_NAME
+)
+CKPT_PATH = "checkpoints/epoch0.ckpt"
+
+model = torchvision.models.resnet50()
+
+with ckpt.writer(CKPT_PATH) as writer:
+  torch.save(model.state_dict(), writer)
+
+with ckpt.reader(CKPT_PATH) as reader:
+  read_state_dict = torch.load(reader)
+
+model.load_state_dict(read_state_dict)
 ```
 
 ## Performance

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ for each_object in dataset:
 
 #### Checkpointing
 
-The Dataflux Dataset for PyTorch not only supports fast data loading but also allows you to save and load model checkpoints directly to and from a Google Cloud Storage (GCS) bucket.
+The Dataflux Dataset for PyTorch supports fast data loading and allows the user to save and load model checkpoints directly to/from a Google Cloud Storage (GCS) bucket.
 
 ```python
 import torch

--- a/dataflux_pytorch/dataflux_checkpoint.py
+++ b/dataflux_pytorch/dataflux_checkpoint.py
@@ -22,9 +22,9 @@ from typing import Optional
 
 
 class DatafluxCheckpoint:
-    """A class that implements the interface of saving and loading model checkpoints.
+    """Implements the interface of saving and loading model checkpoints.
 
-    The reader and writer returns a BlobReader and BlobWriter respectively, which
+    The reader and writer return a BlobReader and BlobWriter respectively, which
     both implement io.BufferedIOBase. Therefore, they can be safely passed to torch.load()
     and torch.save() to load and save model checkpoints.
     """
@@ -42,10 +42,7 @@ class DatafluxCheckpoint:
             bucket_name: The name of the GCS bucket that is going to hold the checkpoint.
             storage_client: The google.cloud.storage.Client object initiated with sufficient
                 permission to access the project and the bucket. If not specified, it will
-                be created during initialization.
-
-        Returns:
-            None.
+                be created during initialization with background authentication.
         """
         self.project_name = project_name
         self.bucket_name = bucket_name

--- a/dataflux_pytorch/dataflux_checkpoint.py
+++ b/dataflux_pytorch/dataflux_checkpoint.py
@@ -1,0 +1,66 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+from google.cloud import storage
+from google.cloud.storage.fileio import BlobReader, BlobWriter
+from google.api_core.client_info import ClientInfo
+
+from typing import Optional
+
+
+class DatafluxCheckpoint:
+    """A class that implements the interface of saving and loading model checkpoints.
+
+    The reader and writer returns a BlobReader and BlobWriter respectively, which
+    both implement io.BufferedIOBase. Therefore, they can be safely passed to torch.load()
+    and torch.save() to load and save model checkpoints.
+    """
+
+    def __init__(
+        self,
+        project_name: str,
+        bucket_name: str,
+        storage_client: Optional[storage.Client] = None,
+    ):
+        """Initializes the DatafluxCheckpoint.
+
+        Args:
+            project_name: The name of the GCP project.
+            bucket_name: The name of the GCS bucket that is going to hold the checkpoint.
+            storage_client: The google.cloud.storage.Client object initiated with sufficient
+                permission to access the project and the bucket. If not specified, it will
+                be created during initialization.
+
+        Returns:
+            None.
+        """
+        self.project_name = project_name
+        self.bucket_name = bucket_name
+        self.storage_client = storage_client
+        if not storage_client:
+            self.storage_client = storage.Client(
+                project=self.project_name,
+                client_info=ClientInfo(user_agent="dataflux/0.0"),
+            )
+        self.bucket = self.storage_client.bucket(self.bucket_name)
+
+    def reader(self, object_name: str) -> BlobReader:
+        blob = self.bucket.blob(object_name)
+        return blob.open("rb")
+
+    def writer(self, object_name: str) -> BlobWriter:
+        blob = self.bucket.blob(object_name)
+        return blob.open("wb", ignore_flush=True)


### PR DESCRIPTION
Add checkpointing support for the Dataflux Dataset.

From investigation it seems that we can confidently use [blob.open()](https://cloud.google.com/python/docs/reference/storage/latest/google.cloud.storage.blob.Blob#google_cloud_storage_blob_Blob_open) to create a file handler. 
* `blob.open("rb")` will return a `BlobReader`.
* `blob.open("wb", ignore_flush=True)` will return a `BlobWriter`.

Both types implement `io.BufferedIOBase` so can be passed into `torch.save()` and `torch.load()` like demonstrated in the README.

TODO: I haven't added unit tests to this yet -- I thought about writing mocks but decided to go with fakes. I wanted to share this PR first before making changes to `fake_gcs` so it would make more sense there. Will follow up on this next.

- [x] Tests pass -- tested by running the demo code directly and verified it works.
- [x] Appropriate changes to documentation are included in the PR -- updated the README.