### PR TITLE
Add pyproject.toml to prepare for PyPI release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "gcs-torch-dataflux"
+version = "0.0.0"
+description = "A GCS data loading integration for PyTorch"
+requires-python = ">=3.8,<3.13"
+readme = "README.md"
+maintainers = [
+    { name = "Google Dataflux Dev Team", email = "dataflux-customer-support@google.com" },
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: OS Independent",
+    "Topic :: Utilities",
+]
+
+dependencies = ["torch >= 2.0.1", "numpy", "google-cloud-storage", "absl-py"]
+
+[project.optional-dependencies]
+test = ["pytest"]
+
+[project.urls]
+Homepage = "https://github.com/GoogleCloudPlatform/dataflux-pytorch"
+Issues = "https://github.com/GoogleCloudPlatform/dataflux-pytorch/issues"


### PR DESCRIPTION
Followed the following instructions to write a `pyproject.toml` to prepare for PyPI release:

1. [Packaging Python Projects](https://packaging.python.org/en/latest/tutorials/packaging-projects/)
2. [Packaging Python Projects using setuptools ](https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#package-discovery-and-namespace-packages)

### Testing
Testing is not straightforward for this change because using the test PyPI index to upload the package will result in missing of all the packages such as `setuptools` and `torch`, which are only available in the real index.

Therefore, I went ahead to test in PROD by creating my own PROD account and upload the package [here](https://pypi.org/project/bernardhan-gcs-torch-dataflux/). You can view this and this will be looking identical to the real package.

After this package is released, I tested by creating a fresh venv on my VM, ran `pip install bernardhan-gcs-torch-dataflux` and ran through the simple walkthrough. Found a bug and created a follow-up for it.

After this CL is merged, I will delete the package above and use our official account to publish the official package.

### Next Steps

1. PyPI accounts need to set up 2FA for access. Right now it is bound to my device so every login from our team needs the code generated from my authenticator app. I'll look around on how to unblock this.
2. Set up automatic publisher releases so the release will be automatic from Github Actions. I will use the existing ticket on "Github Test Relase" and add info there.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR