### PR TITLE
Add support for Dataflux Iterable Dataset

### DIFF
--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -26,7 +26,7 @@ import dataflux_core
 
 
 class Config:
-    """Customizable configuration to the DataFluxIterableStyleDataset.
+    """Customizable configuration to the DataFluxIterableDataset.
 
     Attributes:
         sort_listing_results: A boolean flag indicating if data listing results
@@ -61,7 +61,7 @@ class Config:
         self.max_listing_retries = max_listing_retries
 
 
-class DataFluxIterableStyleDataset(data.IterableDataset):
+class DataFluxIterableDataset(data.IterableDataset):
     def __init__(
         self,
         project_name,
@@ -70,7 +70,7 @@ class DataFluxIterableStyleDataset(data.IterableDataset):
         data_format_fn=lambda data: data,
         storage_client=None,
     ):
-        """Initializes the DataFluxIterableStyleDataset.
+        """Initializes the DataFluxIterableDataset.
 
         The initialization sets up the needed configuration and runs data
         listing using the Dataflux algorithm.

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -78,7 +78,7 @@ class DataFluxIterableDataset(data.IterableDataset):
         Args:
             project_name: The name of the GCP project.
             bucket_name: The name of the GCS bucket that holds the objects to compose.
-                The function uploads the the composed object to this bucket too.
+                The Dataflux download algorithm uploads the the composed object to this bucket too.
             destination_blob_name: The name of the composite object to be created.
             config: A dataflux_iterable_dataset.Config object that includes configuration
                 customizations. If not specified, a default config with default parameters is created.
@@ -123,6 +123,7 @@ class DataFluxIterableDataset(data.IterableDataset):
             ]
         else:
             # Multi-process data loading. Split the workload among workers.
+            # Ref: https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset.
             per_worker = int(
                 math.ceil(len(self.objects) / float(worker_info.num_workers))
             )

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -1,0 +1,170 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import os
+import math
+import logging
+
+from torch.utils import data
+from google.cloud import storage
+from google.api_core.client_info import ClientInfo
+
+import dataflux_core
+
+
+class Config:
+    """Customizable configuration to the DataFluxIterableStyleDataset.
+
+    Attributes:
+        sort_listing_results: A boolean flag indicating if data listing results
+            will be alphabetically sorted. Default to False.
+
+        max_composite_object_size: An integer indicating a cap for the maximum
+            size of the composite object in bytes. Default to 100000000 = 100 MiB.
+
+        num_processes: The number of processes to be used in the Dataflux algorithms.
+            Default to the number of CPUs from the running environment.
+
+        prefix: The prefix that is used to list the objects in the bucket with.
+            The default is None which means it will list all the objects in the bucket.
+
+        max_listing_retries: An integer indicating the maximum number of retries
+        to attempt in case of any Python multiprocessing errors during
+        GCS objects listing. Default to 3.
+    """
+
+    def __init__(
+        self,
+        sort_listing_results: bool = False,
+        max_composite_object_size: int = 100000000,
+        num_processes: int = os.cpu_count(),
+        prefix: str = None,
+        max_listing_retries: int = 3,
+    ):
+        self.sort_listing_results = sort_listing_results
+        self.max_composite_object_size = max_composite_object_size
+        self.num_processes = num_processes
+        self.prefix = prefix
+        self.max_listing_retries = max_listing_retries
+
+
+class DataFluxIterableStyleDataset(data.IterableDataset):
+    def __init__(
+        self,
+        project_name,
+        bucket_name,
+        config=Config(),
+        data_format_fn=lambda data: data,
+        storage_client=None,
+    ):
+        """Initializes the DataFluxIterableStyleDataset.
+
+        The initialization sets up the needed configuration and runs data
+        listing using the Dataflux algorithm.
+
+        Args:
+            project_name: The name of the GCP project.
+            bucket_name: The name of the GCS bucket that holds the objects to compose.
+                The function uploads the the composed object to this bucket too.
+            destination_blob_name: The name of the composite object to be created.
+            config: A dataflux_iterable_dataset.Config object that includes configuration
+                customizations. If not specified, a default config with default parameters is created.
+            data_format_fn: A function that formats the downloaded bytes to the desired format.
+                If not specified, the default formatting function leaves the data as-is.
+            storage_client: The google.cloud.storage.Client object initiated with sufficient permission
+                to access the project and the bucket. If not specified, it will be created
+                during initialization.
+        """
+        super().__init__()
+        self.storage_client = storage_client
+        if not storage_client:
+            self.storage_client = storage.Client(
+                project=project_name,
+                client_info=ClientInfo(user_agent="dataflux/0.0"),
+            )
+        self.project_name = project_name
+        self.bucket_name = bucket_name
+        self.data_format_fn = data_format_fn
+        self.config = config
+        self.dataflux_download_optimization_params = (
+            dataflux_core.download.DataFluxDownloadOptimizationParams(
+                max_composite_object_size=self.config.max_composite_object_size
+            )
+        )
+
+        self.objects = self._list_GCS_blobs_with_retry()
+
+    def __iter__(self):
+        worker_info = data.get_worker_info()
+        if worker_info is None:
+            # Single-process data loading.
+            yield from [
+                self.data_format_fn(bytes_content)
+                for bytes_content in dataflux_core.download.dataflux_download_lazy(
+                    project_name=self.project_name,
+                    bucket_name=self.bucket_name,
+                    objects=self.objects,
+                    storage_client=self.storage_client,
+                    dataflux_download_optimization_params=self.dataflux_download_optimization_params,
+                )
+            ]
+        else:
+            # Multi-process data loading. Split the workload among workers.
+            per_worker = int(
+                math.ceil(len(self.objects) / float(worker_info.num_workers))
+            )
+            worker_id = worker_info.id
+            start = worker_id * per_worker
+            end = min(start + per_worker, len(self.objects))
+            yield from [
+                self.data_format_fn(bytes_content)
+                for bytes_content in dataflux_core.download.dataflux_download_lazy(
+                    project_name=self.project_name,
+                    bucket_name=self.bucket_name,
+                    objects=self.objects[start:end],
+                    storage_client=self.storage_client,
+                    dataflux_download_optimization_params=self.dataflux_download_optimization_params,
+                )
+            ]
+
+    def _list_GCS_blobs_with_retry(self):
+        """Retries Dataflux Listing upon exceptions, up to the retries defined in self.config."""
+        error = None
+        listed_objects = []
+        for _ in range(self.config.max_listing_retries):
+            try:
+                listed_objects = dataflux_core.fast_list.ListingController(
+                    max_parallelism=self.config.num_processes,
+                    project=self.project_name,
+                    bucket=self.bucket_name,
+                    sort_results=self.config.sort_listing_results,
+                    prefix=self.config.prefix,
+                ).run()
+            except Exception as e:
+                logging.error(
+                    f"exception {str(e)} caught running Dataflux fast listing."
+                )
+                error = e
+                continue
+
+            # No exception -- we can immediately return the listed objects.
+            else:
+                return listed_objects
+
+        # Did not break the for loop, therefore all attempts
+        # raised an exception.
+        else:
+            raise error

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -77,7 +77,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         Args:
             project_name: The name of the GCP project.
             bucket_name: The name of the GCS bucket that holds the objects to compose.
-                The function uploads the the composed object to this bucket too.
+                The Dataflux download algorithm uploads the the composed object to this bucket too.
             destination_blob_name: The name of the composite object to be created.
             config: A dataflux_mapstyle_dataset.Config object that includes configuration
                 customizations. If not specified, a default config with default parameters is created.

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -1,5 +1,5 @@
 """
- Copyright 2023 Google LLC
+ Copyright 2024 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -37,7 +37,7 @@ class IterableDatasetTestCase(unittest.TestCase):
 
     @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
     def test_init(self, mock_dataflux_core):
-        """Tests the DataFluxIterableStyleDataset can be initiated with the expected listing results."""
+        """Tests the DataFluxIterableDataset can be initiated with the expected listing results."""
         # Arrange.
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
@@ -46,7 +46,7 @@ class IterableDatasetTestCase(unittest.TestCase):
         )
 
         # Act.
-        ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+        ds = dataflux_iterable_dataset.DataFluxIterableDataset(
             project_name=self.project_name,
             bucket_name=self.bucket_name,
             config=self.config,
@@ -63,7 +63,7 @@ class IterableDatasetTestCase(unittest.TestCase):
 
     @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
     def test_init_with_required_parameters(self, mock_dataflux_core):
-        """Tests the DataFluxIterableStyleDataset can be initiated with only the required parameters."""
+        """Tests the DataFluxIterableDataset can be initiated with only the required parameters."""
         # Arrange.
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
@@ -72,7 +72,7 @@ class IterableDatasetTestCase(unittest.TestCase):
         )
 
         # Act.
-        ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+        ds = dataflux_iterable_dataset.DataFluxIterableDataset(
             project_name=self.project_name,
             bucket_name=self.bucket_name,
             # storage_client is optional param but still needed here
@@ -105,7 +105,7 @@ class IterableDatasetTestCase(unittest.TestCase):
         )
 
         # Act.
-        ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+        ds = dataflux_iterable_dataset.DataFluxIterableDataset(
             project_name=self.project_name,
             bucket_name=self.bucket_name,
             config=self.config,
@@ -137,7 +137,7 @@ class IterableDatasetTestCase(unittest.TestCase):
 
         # Act & Assert.
         with self.assertRaises(RuntimeError) as re:
-            ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+            ds = dataflux_iterable_dataset.DataFluxIterableDataset(
                 project_name=self.project_name,
                 bucket_name=self.bucket_name,
                 config=self.config,
@@ -186,7 +186,7 @@ class IterableDatasetTestCase(unittest.TestCase):
         ]
 
         # Act.
-        ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+        ds = dataflux_iterable_dataset.DataFluxIterableDataset(
             project_name=self.project_name,
             bucket_name=self.bucket_name,
             config=self.config,

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -1,0 +1,215 @@
+"""
+ Copyright 2023 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import unittest
+from unittest import mock
+
+from dataflux_client_python.dataflux_core.tests import fake_gcs
+from dataflux_pytorch import dataflux_iterable_dataset
+
+
+class IterableDatasetTestCase(unittest.TestCase):
+    def setUp(self):
+        super().setUp()
+        self.project_name = "foo"
+        self.bucket_name = "bar"
+        self.config = dataflux_iterable_dataset.Config(
+            num_processes=3, max_listing_retries=3, prefix="prefix/"
+        )
+        self.data_format_fn = lambda data: data
+        client = fake_gcs.Client()
+
+        self.want_objects = [("objectA", 1), ("objectB", 2)]
+        self.storage_client = client
+
+    @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
+    def test_init(self, mock_dataflux_core):
+        """Tests the DataFluxIterableStyleDataset can be initiated with the expected listing results."""
+        # Arrange.
+        mock_listing_controller = mock.Mock()
+        mock_listing_controller.run.return_value = self.want_objects
+        mock_dataflux_core.fast_list.ListingController.return_value = (
+            mock_listing_controller
+        )
+
+        # Act.
+        ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+            project_name=self.project_name,
+            bucket_name=self.bucket_name,
+            config=self.config,
+            data_format_fn=self.data_format_fn,
+            storage_client=self.storage_client,
+        )
+
+        # Assert.
+        self.assertEqual(
+            ds.objects,
+            self.want_objects,
+            f"got listed objects {ds.objects}, want {self.want_objects}",
+        )
+
+    @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
+    def test_init_with_required_parameters(self, mock_dataflux_core):
+        """Tests the DataFluxIterableStyleDataset can be initiated with only the required parameters."""
+        # Arrange.
+        mock_listing_controller = mock.Mock()
+        mock_listing_controller.run.return_value = self.want_objects
+        mock_dataflux_core.fast_list.ListingController.return_value = (
+            mock_listing_controller
+        )
+
+        # Act.
+        ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+            project_name=self.project_name,
+            bucket_name=self.bucket_name,
+            # storage_client is optional param but still needed here
+            # to avoid actual storage.Client construction.
+            storage_client=self.storage_client,
+        )
+
+        # Assert.
+        self.assertEqual(
+            ds.objects,
+            self.want_objects,
+            f"got listed objects {ds.objects}, want {self.want_objects}",
+        )
+
+    @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
+    def test_init_retry_exception_passes(self, mock_dataflux_core):
+        """Tests that the initialization retries objects llisting upon exception and passes."""
+        # Arrange.
+        mock_listing_controller = mock.Mock()
+
+        # Simulate that the first invocation raises an exception and the second invocation
+        # passes with the wanted results.
+        mock_listing_controller.run.side_effect = [
+            Exception(),
+            self.want_objects,
+            Exception(),
+        ]
+        mock_dataflux_core.fast_list.ListingController.return_value = (
+            mock_listing_controller
+        )
+
+        # Act.
+        ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+            project_name=self.project_name,
+            bucket_name=self.bucket_name,
+            config=self.config,
+            data_format_fn=self.data_format_fn,
+            storage_client=self.storage_client,
+        )
+
+        # Assert.
+        self.assertEqual(
+            ds.objects,
+            self.want_objects,
+            f"got listed objects {ds.objects}, want {self.want_objects}",
+        )
+
+    @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
+    def test_init_raises_exception_when_retries_exhaust(self, mock_dataflux_core):
+        """Tests that the initialization raises exception upon exhaustive retries."""
+        # Arrange.
+        mock_listing_controller = mock.Mock()
+        want_exception = RuntimeError("123")
+
+        # Simulate that all retries return with exceptions.
+        mock_listing_controller.run.side_effect = [
+            want_exception for _ in range(self.config.max_listing_retries)
+        ]
+        mock_dataflux_core.fast_list.ListingController.return_value = (
+            mock_listing_controller
+        )
+
+        # Act & Assert.
+        with self.assertRaises(RuntimeError) as re:
+            ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+                project_name=self.project_name,
+                bucket_name=self.bucket_name,
+                config=self.config,
+                data_format_fn=self.data_format_fn,
+                storage_client=self.storage_client,
+            )
+            self.assertIsNone(
+                ds.objects,
+                f"got a non-None objects instance variable, want None when all listing retries are exhausted",
+            )
+
+        self.assertEqual(
+            re.exception,
+            want_exception,
+            f"got exception {re.exception}, want {want_exception}",
+        )
+
+    @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
+    @mock.patch("torch.utils.data")
+    def test_iter(self, mock_torch_utils_data, mock_dataflux_core):
+        """Tests that the using the iterator of the dataset downloads the list of the correct objects."""
+        # Arrange.
+        mock_listing_controller = mock.Mock()
+        mock_listing_controller.run.return_value = self.want_objects
+        mock_dataflux_core.fast_list.ListingController.return_value = (
+            mock_listing_controller
+        )
+        want_optimization_params = object()
+        mock_dataflux_core.download.DataFluxDownloadOptimizationParams.return_value = (
+            want_optimization_params
+        )
+        dataflux_download_return_val = [
+            bytes("contentA", "utf-8"),
+            bytes("contentBB", "utf-8"),
+        ]
+
+        mock_dataflux_core.download.dataflux_download_lazy.return_value = iter(
+            dataflux_download_return_val
+        )
+        mock_torch_utils_data.get_worker_info.return_value = None
+
+        data_format_fn = lambda content: len(content)
+        want_downloaded = [
+            data_format_fn(bytes_content)
+            for bytes_content in dataflux_download_return_val
+        ]
+
+        # Act.
+        ds = dataflux_iterable_dataset.DataFluxIterableStyleDataset(
+            project_name=self.project_name,
+            bucket_name=self.bucket_name,
+            config=self.config,
+            data_format_fn=data_format_fn,
+            storage_client=self.storage_client,
+        )
+        got_downloaded = []
+        for downloaded in ds:
+            got_downloaded.append(downloaded)
+
+        # Assert.
+        self.assertEqual(
+            got_downloaded,
+            want_downloaded,
+        )
+        mock_dataflux_core.download.dataflux_download_lazy.assert_called_with(
+            project_name=self.project_name,
+            bucket_name=self.bucket_name,
+            objects=self.want_objects,
+            storage_client=self.storage_client,
+            dataflux_download_optimization_params=want_optimization_params,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -1,5 +1,5 @@
 """
- Copyright 2023 Google LLC
+ Copyright 2024 Google LLC
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.


### PR DESCRIPTION
Implement DatafluxIterableDataset based on [design](https://docs.google.com/document/d/1SrodotAH7Z2QG6Lx-PZmCRRp4bC2u_U_58TmBjIDRz8/edit?resourcekey=0-4-2exqxutJbVrmSwD3LGyg&tab=t.0#heading=h.hakufr96ezb).

Based on https://pytorch.org/docs/2.1/data.html#torch.utils.data.IterableDataset, we will need to implement workload splitting in the `__iter__()` method.

Tested by running the unit test and running a simple main function:
```
if __name__ == "__main__":
    ds = DataFluxIterableDataset(
        project_name="dataflux-project",
        bucket_name="bernardhan-test-real-demo",
        config=Config(prefix="simple-demo-dataset"),
        data_format_fn=lambda data: 11111111,
    )
    print(ds.objects)
    data_loader = data.DataLoader(ds, batch_size=3, num_workers=3)
    total = 0
    for batch in data_loader:
        print(len(batch))
        print(batch)
        total += len(batch)
    print(total)
```

Next step:
1. Upload the package to PyPI with version `0.1.0`.
2. Add to README and the simple demo.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR