### PR TITLE
Bump gcs-torch-dataflux from 0.0.0 to 0.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gcs-torch-dataflux"
-version = "0.0.0"
+version = "0.1.0"
 description = "A GCS data loading integration for PyTorch"
 requires-python = ">=3.8,<3.13"
 readme = "README.md"


### PR DESCRIPTION
With the support of checkpointing and iterable dataset, I think we should be good to bump a MINOR_VERSION from 0 to 1.

I had released this package on PyPI because the demo installs the package directly from PyPI so it needs the iterable dataset changes. I have also created a 0.1.0 tag/release on Github.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR