### PR TITLE
Fix Iterable Dataset bug on downloading the whole subset of data

### DIFF
--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -111,7 +111,7 @@ class DataFluxIterableDataset(data.IterableDataset):
         worker_info = data.get_worker_info()
         if worker_info is None:
             # Single-process data loading.
-            yield from [
+            yield from (
                 self.data_format_fn(bytes_content)
                 for bytes_content in dataflux_core.download.dataflux_download_lazy(
                     project_name=self.project_name,
@@ -120,7 +120,7 @@ class DataFluxIterableDataset(data.IterableDataset):
                     storage_client=self.storage_client,
                     dataflux_download_optimization_params=self.dataflux_download_optimization_params,
                 )
-            ]
+            )
         else:
             # Multi-process data loading. Split the workload among workers.
             # Ref: https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset.
@@ -130,7 +130,7 @@ class DataFluxIterableDataset(data.IterableDataset):
             worker_id = worker_info.id
             start = worker_id * per_worker
             end = min(start + per_worker, len(self.objects))
-            yield from [
+            yield from (
                 self.data_format_fn(bytes_content)
                 for bytes_content in dataflux_core.download.dataflux_download_lazy(
                     project_name=self.project_name,
@@ -139,7 +139,7 @@ class DataFluxIterableDataset(data.IterableDataset):
                     storage_client=self.storage_client,
                     dataflux_download_optimization_params=self.dataflux_download_optimization_params,
                 )
-            ]
+            )
 
     def _list_GCS_blobs_with_retry(self):
         """Retries Dataflux Listing upon exceptions, up to the retries defined in self.config."""


### PR DESCRIPTION
While working on the baseline performance numbers of Dataflux Iterable Dataset I found this critical bug that the previous implementation can ask each worker to download the whole dataset before applying `data_format_fn` to each item.

The bug is caused by using using the `[]` bracket to gather the results which break the generator pattern. Instead, we should use `()`. See more https://lerner.co.il/2018/06/08/python-parentheses-primer/.

The fix is tested by running the unit tests again and also rerun with the large dataset that exceeds the memory. Make sure that the memory utilization is correct. https://screenshot.googleplex.com/8g6A9qtHAiPGQ6r

As a retro:
1. The bug is introduced but didn't get caught by the unit test because in unit test we didn't test the logic of lazy generation of data. It is also likely that we can't test it because 1. the return of `dataflux_download_lazy` is mocked and 2. hard to inject into the code flow to verify that "yield from" is operated on a generator than a list.
2. For the performance tests, we should start to monitor memory usage.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR