### PR TITLE
Update baseline performance numbers for Dataflux datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,13 +159,13 @@ We tested Dataflux Map-style Dataset's early performance using [DLIO benchmark](
    </td>
    <td style="background-color: #d9d9d9">Direct GCS API calls
    </td>
-   <td style="background-color: #d9d9d9">2,459
+   <td style="background-color: #d9d9d9">1,299
    </td>
   </tr>
   <tr>
    <td style="background-color: #d9d9d9"><strong>Dataflux Map-style Dataset</strong>
    </td>
-   <td style="background-color: #d9d9d9"><strong>757</strong>
+   <td style="background-color: #d9d9d9"><strong>515</strong>
    </td>
   </tr>
   <tr>
@@ -173,13 +173,13 @@ We tested Dataflux Map-style Dataset's early performance using [DLIO benchmark](
    </td>
    <td style="background-color: #f3f3f3">Direct GCS API calls
    </td>
-   <td style="background-color: #f3f3f3">7,472
+   <td style="background-color: #f3f3f3">6,499
    </td>
   </tr>
   <tr>
    <td style="background-color: #f3f3f3"><strong>Dataflux Map-style Dataset</strong>
    </td>
-   <td style="background-color: #f3f3f3"><strong>2,696</strong>
+   <td style="background-color: #f3f3f3"><strong>2,058</strong>
    </td>
   </tr>
   <tr>
@@ -187,13 +187,13 @@ We tested Dataflux Map-style Dataset's early performance using [DLIO benchmark](
    </td>
    <td style="background-color: #d9d9d9">Direct GCS API calls
    </td>
-   <td style="background-color: #d9d9d9">463
+   <td style="background-color: #d9d9d9">399
    </td>
   </tr>
   <tr>
    <td style="background-color: #d9d9d9"><strong>Dataflux Map-style Dataset</strong>
    </td>
-   <td style="background-color: #d9d9d9"><strong>318</strong>
+   <td style="background-color: #d9d9d9"><strong>277</strong>
    </td>
   </tr>
   <tr>
@@ -201,13 +201,13 @@ We tested Dataflux Map-style Dataset's early performance using [DLIO benchmark](
    </td>
    <td style="background-color: #f3f3f3">Direct GCS API calls
    </td>
-   <td style="background-color: #f3f3f3">1,228
+   <td style="background-color: #f3f3f3">1,396
    </td>
   </tr>
   <tr>
    <td style="background-color: #f3f3f3"><strong>Dataflux Map-style Dataset</strong>
    </td>
-   <td style="background-color: #f3f3f3"><strong>1,288</strong>
+   <td style="background-color: #f3f3f3"><strong>1,173</strong>
    </td>
   </tr>
 </table>
@@ -229,13 +229,13 @@ Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesnâ
    </td>
    <td style="background-color: #d9d9d9">Direct GCS API calls
    </td>
-   <td style="background-color: #d9d9d9">2,257
+   <td style="background-color: #d9d9d9">1,145
    </td>
   </tr>
   <tr>
    <td style="background-color: #d9d9d9"><strong>Dataflux Iterable-style Dataset</strong>
    </td>
-   <td style="background-color: #d9d9d9"><strong>589</strong>
+   <td style="background-color: #d9d9d9"><strong>611</strong>
    </td>
   </tr>
   <tr>
@@ -243,13 +243,13 @@ Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesnâ
    </td>
    <td style="background-color: #f3f3f3">Direct GCS API calls
    </td>
-   <td style="background-color: #f3f3f3">7,097
+   <td style="background-color: #f3f3f3">5,174
    </td>
   </tr>
   <tr>
    <td style="background-color: #f3f3f3"><strong>Dataflux Iterable-style Dataset</strong>
    </td>
-   <td style="background-color: #f3f3f3"><strong>2,242</strong>
+   <td style="background-color: #f3f3f3"><strong>2,503</strong>
    </td>
   </tr>
   <tr>
@@ -257,13 +257,13 @@ Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesnâ
    </td>
    <td style="background-color: #d9d9d9">Direct GCS API calls
    </td>
-   <td style="background-color: #d9d9d9">451
+   <td style="background-color: #d9d9d9">413
    </td>
   </tr>
   <tr>
    <td style="background-color: #d9d9d9"><strong>Dataflux Iterable-style Dataset</strong>
    </td>
-   <td style="background-color: #d9d9d9"><strong>408</strong>
+   <td style="background-color: #d9d9d9"><strong>384</strong>
    </td>
   </tr>
   <tr>
@@ -271,13 +271,13 @@ Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesnâ
    </td>
    <td style="background-color: #f3f3f3">Direct GCS API calls
    </td>
-   <td style="background-color: #f3f3f3">1,558
+   <td style="background-color: #f3f3f3">1,225
    </td>
   </tr>
   <tr>
    <td style="background-color: #f3f3f3"><strong>Dataflux Iterable-style Dataset</strong>
    </td>
-   <td style="background-color: #f3f3f3"><strong>1,506</strong>
+   <td style="background-color: #f3f3f3"><strong>1,143</strong>
    </td>
   </tr>
 </table>

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ We tested Dataflux Map-style Dataset's early performance using [DLIO benchmark](
 </table>
 
 ### Dataflux Iterable-style Dataset
-Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesn’t easily support an implementation of a PyTorch iterable dataset, we implemented a simple training loop that has similar IO behaviors as the DLIO benchmark and used that loop to benchmark the Dataflux Iterable Datasets.
+Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesn’t easily support an implementation of a PyTorch iterable dataset, we implemented a [simple training loop](demo/simple_iterable_dataset.py) that has similar IO behaviors as the DLIO benchmark and used that loop to benchmark the Dataflux Iterable Datasets.
 
 <table>
   <tr>

--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ model.load_state_dict(read_state_dict)
 ```
 
 ## Performance
-We tested Dataflux's early performance using [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) simulations with standard mean file-sizes and dataset sizes. A total of 5 training epochs were simulated. For small files (100KB, 500KB), Dataflux can be **2-3x** faster than using GCS native APIs.
+
+### Dataflux Map-style Dataset
+We tested Dataflux Map-style Dataset's early performance using [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) simulations with standard mean file-sizes and dataset sizes. A total of 5 training epochs were simulated. For small files (100KB, 500KB), Dataflux can be **2-3x** faster than using GCS native APIs.
 
 <table>
   <tr>
@@ -161,7 +163,7 @@ We tested Dataflux's early performance using [DLIO benchmark](https://github.com
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9"><strong>Dataflux</strong>
+   <td style="background-color: #d9d9d9"><strong>Dataflux Map-style Dataset</strong>
    </td>
    <td style="background-color: #d9d9d9"><strong>757</strong>
    </td>
@@ -175,7 +177,7 @@ We tested Dataflux's early performance using [DLIO benchmark](https://github.com
    </td>
   </tr>
   <tr>
-   <td style="background-color: #f3f3f3"><strong>Dataflux</strong>
+   <td style="background-color: #f3f3f3"><strong>Dataflux Map-style Dataset</strong>
    </td>
    <td style="background-color: #f3f3f3"><strong>2,696</strong>
    </td>
@@ -189,7 +191,7 @@ We tested Dataflux's early performance using [DLIO benchmark](https://github.com
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9"><strong>Dataflux</strong>
+   <td style="background-color: #d9d9d9"><strong>Dataflux Map-style Dataset</strong>
    </td>
    <td style="background-color: #d9d9d9"><strong>318</strong>
    </td>
@@ -203,9 +205,79 @@ We tested Dataflux's early performance using [DLIO benchmark](https://github.com
    </td>
   </tr>
   <tr>
-   <td style="background-color: #f3f3f3"><strong>Dataflux</strong>
+   <td style="background-color: #f3f3f3"><strong>Dataflux Map-style Dataset</strong>
    </td>
    <td style="background-color: #f3f3f3"><strong>1,288</strong>
+   </td>
+  </tr>
+</table>
+
+### Dataflux Iterable-style Dataset
+Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesn’t easily support an implementation of a PyTorch iterable dataset, we implemented a simple training loop that has similar IO behaviors as the DLIO benchmark and used that loop to benchmark the Dataflux Iterable Datasets.
+
+<table>
+  <tr>
+   <td style="background-color: #d9d2e9"><strong>File size / count</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Tool</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Training time (s)</strong>
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2" style="background-color: #d9d9d9"><em>100 KiB / 500000 files</em>
+   </td>
+   <td style="background-color: #d9d9d9">Direct GCS API calls
+   </td>
+   <td style="background-color: #d9d9d9">2,257
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9"><strong>Dataflux Iterable-style Dataset</strong>
+   </td>
+   <td style="background-color: #d9d9d9"><strong>589</strong>
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2" style="background-color: #f3f3f3"><em>500 KiB / 2.2m files</em>
+   </td>
+   <td style="background-color: #f3f3f3">Direct GCS API calls
+   </td>
+   <td style="background-color: #f3f3f3">7,097
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3"><strong>Dataflux Iterable-style Dataset</strong>
+   </td>
+   <td style="background-color: #f3f3f3"><strong>2,242</strong>
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2" style="background-color: #d9d9d9"><em>3 MiB / 50000 files</em>
+   </td>
+   <td style="background-color: #d9d9d9">Direct GCS API calls
+   </td>
+   <td style="background-color: #d9d9d9">451
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9"><strong>Dataflux Iterable-style Dataset</strong>
+   </td>
+   <td style="background-color: #d9d9d9"><strong>408</strong>
+   </td>
+  </tr>
+  <tr>
+   <td rowspan="2" style="background-color: #f3f3f3"><em>150 MiB / 5000 files</em>
+   </td>
+   <td style="background-color: #f3f3f3">Direct GCS API calls
+   </td>
+   <td style="background-color: #f3f3f3">1,558
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3"><strong>Dataflux Iterable-style Dataset</strong>
+   </td>
+   <td style="background-color: #f3f3f3"><strong>1,506</strong>
    </td>
   </tr>
 </table>

--- a/demo/simple_iterable_dataset.py
+++ b/demo/simple_iterable_dataset.py
@@ -1,0 +1,122 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import numpy
+import io
+import argparse
+import time
+
+from torch.utils import data
+from dataflux_pytorch import dataflux_iterable_dataset
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", type=str)
+    parser.add_argument("--bucket", type=str)
+    parser.add_argument("--prefix", type=str)
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--num-workers", type=int, default=0)
+    parser.add_argument("--no-dataflux", type=bool, default=False)
+    parser.add_argument("--batch-size", type=int, default=100)
+    parser.add_argument("--sleep_per_step", type=float, default=1.3604)
+    parser.add_argument("--prefetch-factor", type=int, default=2)
+    return parser.parse_args()
+
+
+"""
+Sample training loop that utilizes the Dataflux Iterable Dataset, iterates over the given bucket and 
+counts the number of objects/bytes. For example:
+
+$ python3 -m demo.simple_iterable_dataset --project=<YOUR_PROJECT> --bucket=<YOUR_BUCKET> --prefix=<YOUR_PREFIX> --epochs=2 --num-workers=8
+
+You can also use the --no-dataflux flag to override the configuration so that listing
+is done sequentially and objects are downloaded individually, allowing you to compare
+performance numbers from Dataflux to a naive GCS-API implementation without Dataflux's
+algorithms.
+"""
+
+
+def main():
+    args = parse_args()
+    list_start_time = time.time()
+    config = dataflux_iterable_dataset.Config()
+    if args.no_dataflux:
+        print(
+            "Overriding parallelism and composite object configurations to simulate non-dataflux loop"
+        )
+        config.max_composite_object_size = 0
+        config.num_processes = 1
+    print(f"Listing started at time {list_start_time}")
+
+    # Define the data_format_fn to transform the data samples.
+    # NOTE: Make sure to modify this to fit your data format.
+    def read_image_modified(content_in_bytes):
+        return numpy.load(io.BytesIO(content_in_bytes), allow_pickle=True)["x"]
+
+    if args.prefix:
+        config.prefix = args.prefix
+
+    dataset = dataflux_iterable_dataset.DataFluxIterableDataset(
+        project_name=args.project,
+        bucket_name=args.bucket,
+        config=config,
+        data_format_fn=read_image_modified,
+    )
+    list_end_time = time.time()
+    print(
+        f"Listing discovered {len(dataset.objects)} objects in {list_end_time - list_start_time} seconds."
+    )
+    data_loader = data.DataLoader(
+        dataset=dataset,
+        batch_size=args.batch_size,
+        num_workers=args.num_workers,
+        prefetch_factor=args.prefetch_factor,
+        persistent_workers=True,
+        pin_memory=True,
+    )
+    training_start_time = time.time()
+    print(f"Training started at time {training_start_time}")
+    for i in range(args.epochs):
+        total_objects = 0
+        total_bytes = 0
+        epoch_start = time.time()
+        last_update = time.time()
+        for batch in data_loader:
+            # A simple sleep function to simulate the GPU training time.
+            if args.sleep_per_step:
+                time.sleep(args.sleep_per_step)
+
+            total_objects += len(batch)
+            for object_bytes in batch:
+                total_bytes += len(object_bytes)
+            if time.time() - last_update > 5:
+                print(
+                    f"Iterated over {total_objects} objects and {total_bytes} bytes so far"
+                )
+                last_update = time.time()
+        epoch_end = time.time()
+        print(
+            f"Epoch {i} took {epoch_end - epoch_start} seconds to iterate over {total_objects} objects and {total_bytes} bytes."
+        )
+    training_end_time = time.time()
+    print(
+        f"All training ({args.epochs} epochs) took {training_end_time - training_start_time} seconds."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/demo/simple_map_style_dataset.py
+++ b/demo/simple_map_style_dataset.py
@@ -13,66 +13,79 @@
  See the License for the specific language governing permissions and
  limitations under the License.
  """
+
 import argparse
 import time
+import numpy
+import io
 
 from torch.utils import data
 from dataflux_pytorch import dataflux_mapstyle_dataset
+
 
 def parse_args():
     parser = argparse.ArgumentParser()
     parser.add_argument("--project", type=str)
     parser.add_argument("--bucket", type=str)
+    parser.add_argument("--prefix", type=str)
     parser.add_argument("--epochs", type=int, default=10)
     parser.add_argument("--num-workers", type=int, default=0)
     parser.add_argument("--no-dataflux", type=bool, default=False)
     parser.add_argument("--batch-size", type=int, default=100)
+    parser.add_argument("--sleep_per_step", type=float, default=1.3604)
     parser.add_argument("--prefetch-factor", type=int, default=2)
     return parser.parse_args()
 
+
 """
-Sample training loop that iterates over the given bucket and counts the number of objects/bytes. For example:
+Sample training loop that utilizes the Dataflux Map-style Dataset, iterates over the given bucket and 
+counts the number of objects/bytes. For example:
 
-$ python3 -m demo.simple_list_iterate --project=zimbruplayground --bucket=bernardhan-diffusion-small --epochs=2 --num-workers=8
-
-Listing started at time 1706310135.8997579
-Listing discovered 10003 objects in 4.665696382522583 seconds.
-Training started at time 1706310140.5665798
-Iterated over 200 objects and 118331981 bytes so far
-Iterated over 1700 objects and 1026198500 bytes so far
-Iterated over 3300 objects and 2081709038 bytes so far
-Iterated over 4900 objects and 3079001576 bytes so far
-Iterated over 6500 objects and 4110702193 bytes so far
-Iterated over 8100 objects and 5112547098 bytes so far
-Epoch 0 took 38.01222038269043 seconds to iterate over 10003 objects and 6320912111 bytes.
-Iterated over 200 objects and 138402866 bytes so far
-Iterated over 2100 objects and 1295573582 bytes so far
-Iterated over 3400 objects and 2127651395 bytes so far
-Iterated over 5300 objects and 3317803831 bytes so far
-Iterated over 6200 objects and 3884287582 bytes so far
-Iterated over 8400 objects and 5267435784 bytes so far
-Iterated over 9400 objects and 5929520073 bytes so far
-Epoch 1 took 37.49032020568848 seconds to iterate over 10003 objects and 6320912111 bytes.
-All training (2 epochs) took 75.50275588035583 seconds.
+$ python3 -m demo.simple_map_style_dataset --project=<YOUR_PROJECT> --bucket=<YOUR_BUCKET> --prefix=<YOUR_PREFIX> --epochs=2 --num-workers=8
 
 You can also use the --no-dataflux flag to override the configuration so that listing
 is done sequentially and objects are downloaded individually, allowing you to compare
 performance numbers from Dataflux to a naive GCS-API implementation without Dataflux's
-algorithms. In this case, all training on the bucket above takes 400 seconds.
+algorithms.
 """
+
+
 def main():
     args = parse_args()
     list_start_time = time.time()
     config = dataflux_mapstyle_dataset.Config()
     if args.no_dataflux:
-        print("Overriding parallelism and composite object configurations to simulate non-dataflux loop")
+        print(
+            "Overriding parallelism and composite object configurations to simulate non-dataflux loop"
+        )
         config.max_composite_object_size = 0
         config.num_processes = 1
     print(f"Listing started at time {list_start_time}")
-    dataset = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(args.project, args.bucket, config=config)
+
+    # Define the data_format_fn to transform the data samples.
+    # NOTE: Make sure to modify this to fit your data format.
+    def read_image_modified(content_in_bytes):
+        return numpy.load(io.BytesIO(content_in_bytes), allow_pickle=True)["x"]
+
+    dataset = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
+        project_name=args.project,
+        bucket_name=args.bucket,
+        config=config,
+        data_format_fn=read_image_modified,
+    )
     list_end_time = time.time()
-    print(f"Listing discovered {len(dataset)} objects in {list_end_time - list_start_time} seconds.")
-    data_loader = data.DataLoader(dataset=dataset, batch_size=args.batch_size, shuffle=True, num_workers=args.num_workers, prefetch_factor=args.prefetch_factor)
+    print(
+        f"Listing discovered {len(dataset)} objects in {list_end_time - list_start_time} seconds."
+    )
+    data_loader = data.DataLoader(
+        dataset=dataset,
+        batch_size=args.batch_size,
+        shuffle=True,
+        num_workers=args.num_workers,
+        prefetch_factor=args.prefetch_factor,
+        persistent_workers=True,
+        pin_memory=True,
+    )
     training_start_time = time.time()
     print(f"Training started at time {training_start_time}")
     for i in range(args.epochs):
@@ -86,12 +99,19 @@ def main():
             for object_bytes in batch:
                 total_bytes += len(object_bytes)
             if time.time() - last_update > 5:
-                print(f"Iterated over {total_objects} objects and {total_bytes} bytes so far")
+                print(
+                    f"Iterated over {total_objects} objects and {total_bytes} bytes so far"
+                )
                 last_update = time.time()
         epoch_end = time.time()
-        print(f"Epoch {i} took {epoch_end - epoch_start} seconds to iterate over {total_objects} objects and {total_bytes} bytes.")
+        print(
+            f"Epoch {i} took {epoch_end - epoch_start} seconds to iterate over {total_objects} objects and {total_bytes} bytes."
+        )
     training_end_time = time.time()
-    print(f"All training ({args.epochs} epochs) took {training_end_time - training_start_time} seconds.")
+    print(
+        f"All training ({args.epochs} epochs) took {training_end_time - training_start_time} seconds."
+    )
+
 
 if __name__ == "__main__":
     main()

--- a/demo/simple_map_style_dataset.py
+++ b/demo/simple_map_style_dataset.py
@@ -67,6 +67,9 @@ def main():
     def read_image_modified(content_in_bytes):
         return numpy.load(io.BytesIO(content_in_bytes), allow_pickle=True)["x"]
 
+    if args.prefix:
+        config.prefix = args.prefix
+
     dataset = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
         project_name=args.project,
         bucket_name=args.bucket,


### PR DESCRIPTION
Suggest to use "Display the rich diff" to review.

This PR updates the baseline performance numbers for Dataflux iterable dataset. Please review [this document](https://docs.google.com/document/d/19L2BKsXR9wTzMS0-hCvs6Wi4tTtutU2UfZoCV5OSuM4/edit?resourcekey=0-eMHwcwK4AddR2OUmo6iJIw&tab=t.0#heading=h.ar03bi1o136q) for the contexts.

This PR also updates the baseline performance numbers of the Dataflux map-style datasets to match the Tesseract results.

Finally, this PR adds the simple demo training loop that uses the iterable style dataset and updates the map style dataset.

TESTED by running `python3 -m demo.simple_map_style_dataset --project=dataflux-project --bucket=official-dataflux-tess --prefix=UNet3D/medium/3MB-150GB/train --epochs=5 --num-workers=96 --batch-size=256 --sleep_per_step=0.17005` and `python3 -m demo.simple_iterable_dataset --project=dataflux-project --bucket=official-dataflux-tess --prefix=UNet3D/medium/3MB-150GB/train --epochs=5 --num-workers=96 --batch-size=256 --sleep_per_step=0.17005` on a VM.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR