### PR TITLE
Debug logging for Kokoro unit test build

### DIFF
--- a/kokoro/build.sh
+++ b/kokoro/build.sh
@@ -43,7 +43,7 @@ function install_requirements() {
 
 function run_unit_tests() {
     echo Running unit tests.
-    python -m pytest dataflux_pytorch/tests --junit-xml="${KOKORO_ARTIFACTS_DIR}/unit_tests/sponge_log.xml"
+    python -m pytest dataflux_pytorch/tests --junit-xml="${KOKORO_ARTIFACTS_DIR}/unit_tests/sponge_log.xml" --log-cli-level=DEBUG
 }
 
 run_git_commands


### PR DESCRIPTION
This will make the logs more informative when debugging test failures on Kokoro.

This was used in
https://github.com/GoogleCloudPlatform/dataflux-client-python/pull/31 to help understand why JD's PR was failing tests on Kokoro despite passing locally.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR