### PR TITLE
bump version to 1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gcs-torch-dataflux"
-version = "0.1.0"
+version = "1.0.0"
 description = "A GCS data loading integration for PyTorch"
 requires-python = ">=3.8,<3.13"
 readme = "README.md"
@@ -12,7 +12,7 @@ maintainers = [
     { name = "Google Dataflux Dev Team", email = "dataflux-customer-support@google.com" },
 ]
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",


### PR DESCRIPTION
Bump version to 1.0.0 to prepare for Cloud NEXT.

This PR also updates the dataflux-client-python submodule to point to the latest main at 2ab47cfaf0a52f87c619d552c526ab53dda7e8d9

Next step is to manually release to PyPI since we haven't set up the auto release yet.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR