### PR TITLE
Add a new flag for specifying number of dataloader threads

### DIFF
--- a/demo/image-segmentation/arguments.py
+++ b/demo/image-segmentation/arguments.py
@@ -39,6 +39,7 @@ PARSER.add_argument("--input_shape", nargs="+", type=int, default=[128, 128, 128
 PARSER.add_argument("--val_input_shape", nargs="+", type=int, default=[128, 128, 128])
 PARSER.add_argument("--seed", dest="seed", default=-1, type=int)
 PARSER.add_argument("--num_workers", dest="num_workers", type=int, default=8)
+PARSER.add_argument("--num_dataloader_threads", dest="num_dataloader_threads", type=int, default=8)
 PARSER.add_argument(
     "--exec_mode", dest="exec_mode", choices=["train", "evaluate"], default="train"
 )

--- a/demo/image-segmentation/data_loader.py
+++ b/demo/image-segmentation/data_loader.py
@@ -149,7 +149,7 @@ def get_data_loaders(flags, num_shards, global_rank):
         batch_size=flags.batch_size,
         shuffle=not flags.benchmark and train_sampler is None,
         sampler=train_sampler,
-        num_workers=flags.num_workers,
+        num_workers=flags.num_dataloader_threads,
         pin_memory=True,
         drop_last=True,
     )

--- a/demo/image-segmentation/run_and_time.sh
+++ b/demo/image-segmentation/run_and_time.sh
@@ -24,6 +24,7 @@ EVALUATE_EVERY=20
 LEARNING_RATE="0.8"
 LR_WARMUP_EPOCHS=20
 NUM_WORKERS=8
+NUM_DATALOADER_THREADS=8
 BATCH_SIZE=32
 GRADIENT_ACCUMULATION_STEPS=1
 SEED=5
@@ -39,6 +40,7 @@ echo "STARTING TIMING RUN AT $start_fmt"
 
 python train.py \
   --num_workers=${NUM_WORKERS} \
+  --num_dataloader_threads=${NUM_DATALOADER_THREADS} \
   --epochs=${MAX_EPOCHS} \
   --evaluate_every=${EVALUATE_EVERY} \
   --start_eval_at=${START_EVAL_AT} \


### PR DESCRIPTION
We currently set the number of data loader threads to the number of workers (GPUs). Having a separate flag for specifying number of data loader threads makes it easy to test with different values.