### PR TITLE
add disable_compose config

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,8 +325,7 @@ To optimize the download performance of small files, the Accelerated Dataloader 
 gcloud storage rm --recursive gs://<my-bucket>/dataflux-composed-objects/
 ```
 
-You can also turn off this behavior by setting the “max_composite_object_size” parameter to 0 when constructing the dataset. Example:
-
+You can turn of this behavior by setting the "disable_compose" parameter to true, or by setting the “max_composite_object_size” parameter to 0 when constructing the dataset. Example:
 ```python
 dataset = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
   project_name=PROJECT_NAME,
@@ -334,11 +333,14 @@ dataset = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
   config=dataflux_mapstyle_dataset.Config(
     prefix=PREFIX,
     max_composite_object_size=0,
+    disable_compose=True,
   ),
 )
 ```
 
-Note that turning off this behavior will cause the training loop to take significantly longer to complete when working with small files.
+**Note that this feature should always be disabled for highly scaled operations that are likely to approach the maximum throughput speeds allowed in the user project.** If left enabled on such operations, users are likely to hit their throughput limit earlier than expected.
+
+Turning off this behavior will cause the training loop to take significantly longer to complete when working with small files when the operation is not approaching project throughput or QPS limits.
 
 ### Soft Delete
 To avoid storage charges for retaining the temporary composite objects, consider disabling the [Soft Delete](https://cloud.google.com/storage/docs/soft-delete) retention duration on the bucket.

--- a/README.md
+++ b/README.md
@@ -338,9 +338,8 @@ dataset = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
 )
 ```
 
-**Note that this feature should always be disabled for highly scaled operations that are likely to approach the maximum throughput speeds allowed in the user project.** If left enabled on such operations, users are likely to hit their throughput limit earlier than expected.
+Note that turning off this behavior may cause the training loop to take significantly longer to complete when working with small files. However, composed download will hit QPS and throughput limits at a lower scale than downloading files directly, so you should disable this behavior when running at high multi-node scales where you are able to hit project QPS or throughput limits without composed download.
 
-Turning off this behavior will cause the training loop to take significantly longer to complete when working with small files when the operation is not approaching project throughput or QPS limits.
 
 ### Soft Delete
 To avoid storage charges for retaining the temporary composite objects, consider disabling the [Soft Delete](https://cloud.google.com/storage/docs/soft-delete) retention duration on the bucket.

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -44,6 +44,9 @@ class Config:
         max_listing_retries: An integer indicating the maximum number of retries
         to attempt in case of any Python multiprocessing errors during
         GCS objects listing. Default to 3.
+
+        disable_compose: A boolean flag indicating if compose download should be active.
+        Compose should be disabled for highly scaled implementations.
     """
 
     def __init__(
@@ -53,12 +56,15 @@ class Config:
         num_processes: int = os.cpu_count(),
         prefix: str = None,
         max_listing_retries: int = 3,
+        disable_compose: bool = False,
     ):
         self.sort_listing_results = sort_listing_results
         self.max_composite_object_size = max_composite_object_size
         self.num_processes = num_processes
         self.prefix = prefix
         self.max_listing_retries = max_listing_retries
+        if disable_compose:
+            self.max_composite_object_size = 0
 
 
 class DataFluxIterableDataset(data.IterableDataset):

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -43,6 +43,9 @@ class Config:
         max_listing_retries: An integer indicating the maximum number of retries
         to attempt in case of any Python multiprocessing errors during
         GCS objects listing. Default to 3.
+
+        disable_compose: A boolean flag indicating if compose download should be active.
+        Compose should be disabled for highly scaled implementations.
     """
 
     def __init__(
@@ -53,6 +56,7 @@ class Config:
         prefix: str = None,
         max_listing_retries: int = 3,
         threads_per_process: int = 1,
+        disable_compose: bool = False,
     ):
         self.sort_listing_results = sort_listing_results
         self.max_composite_object_size = max_composite_object_size
@@ -60,6 +64,8 @@ class Config:
         self.prefix = prefix
         self.max_listing_retries = max_listing_retries
         self.threads_per_process = threads_per_process
+        if disable_compose:
+            self.max_composite_object_size = 0
 
 
 class DataFluxMapStyleDataset(data.Dataset):


### PR DESCRIPTION
Add explicit flag to disable compose. High scale operations must disable compose to avoid errors due to high read/write load caused by compose calls.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR