### PR TITLE
Fix continuous and presubmit tests

### DIFF
--- a/kokoro/build.sh
+++ b/kokoro/build.sh
@@ -21,6 +21,8 @@ set -e
 cd "${KOKORO_ARTIFACTS_DIR}/github/dataflux-pytorch"
 
 function setup_virtual_envs() {
+    sudo apt-get update
+    
     echo Setting up Python virtual environment.
     sudo apt install python3.8-venv
     python3 -m venv venv

--- a/kokoro/build.sh
+++ b/kokoro/build.sh
@@ -21,8 +21,8 @@ set -e
 cd "${KOKORO_ARTIFACTS_DIR}/github/dataflux-pytorch"
 
 function setup_virtual_envs() {
-    sudo apt-get update
-    
+    sudo apt-get -y update
+
     echo Setting up Python virtual environment.
     sudo apt install python3.8-venv
     python3 -m venv venv

--- a/kokoro/build.sh
+++ b/kokoro/build.sh
@@ -24,7 +24,7 @@ function setup_virtual_envs() {
     sudo apt-get -y update
 
     echo Setting up Python virtual environment.
-    sudo apt install python3.8-venv
+    sudo apt install -y python3.8-venv
     python3 -m venv venv
     source venv/bin/activate
 }

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -21,6 +21,8 @@ set -e
 cd "${KOKORO_ARTIFACTS_DIR}/github/dataflux-pytorch"
 
 function setup_virtual_envs() {
+    sudo apt-get update
+    
     echo Setting up Python virtual environment.
     sudo apt install python3.8-venv
     python3 -m venv venv

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -21,8 +21,8 @@ set -e
 cd "${KOKORO_ARTIFACTS_DIR}/github/dataflux-pytorch"
 
 function setup_virtual_envs() {
-    sudo apt-get update
-    
+    sudo apt-get -y update
+
     echo Setting up Python virtual environment.
     sudo apt install python3.8-venv
     python3 -m venv venv

--- a/kokoro/presubmit.sh
+++ b/kokoro/presubmit.sh
@@ -24,7 +24,7 @@ function setup_virtual_envs() {
     sudo apt-get -y update
 
     echo Setting up Python virtual environment.
-    sudo apt install python3.8-venv
+    sudo apt install -y python3.8-venv
     python3 -m venv venv
     source venv/bin/activate
 }


### PR DESCRIPTION
Fixes the failing continuous tests.

We needed a `sudo apt-get -y update` to update the list of archives.

Tested by triggering a manual build [here](https://fusion2.corp.google.com/ci/kokoro/prod:cloud-storage-ml-infra-dataflux%2Fdataflux-pytorch%2Fcontinuous/activity/6172403c-3b0a-4954-9bce-6c58c64e98f9/log).

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR