### PR TITLE
Bump version to 1.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "gcs-torch-dataflux"
-version = "1.0.0"
+version = "1.1.0"
 description = "A GCS data loading integration for PyTorch"
 requires-python = ">=3.8,<3.13"
 readme = "README.md"
@@ -24,7 +24,13 @@ classifiers = [
     "Topic :: Utilities",
 ]
 
-dependencies = ["torch >= 2.0.1", "numpy", "google-cloud-storage", "absl-py", "lightning >= 2.0"]
+dependencies = [
+    "torch >= 2.0.1",
+    "numpy",
+    "google-cloud-storage",
+    "absl-py",
+    "lightning >= 2.0",
+]
 
 [project.optional-dependencies]
 test = ["pytest"]


### PR DESCRIPTION
Need to bump the version to 1.1.0, which I missed in the demo this afternoon.

I will then finish the release and add the instructions of the manual path to a doc next.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR