### PR TITLE
Set Dataflux user-agent through dataflux_core.user_agent module

### DIFF
--- a/dataflux_pytorch/dataflux_checkpoint.py
+++ b/dataflux_pytorch/dataflux_checkpoint.py
@@ -16,7 +16,8 @@
 
 from google.cloud import storage
 from google.cloud.storage.fileio import BlobReader, BlobWriter
-from google.api_core.client_info import ClientInfo
+
+from dataflux_core import user_agent
 
 from typing import Optional
 
@@ -50,8 +51,8 @@ class DatafluxCheckpoint:
         if not storage_client:
             self.storage_client = storage.Client(
                 project=self.project_name,
-                client_info=ClientInfo(user_agent="dataflux/0.0"),
             )
+        user_agent.add_dataflux_user_agent(self.storage_client)
         self.bucket = self.storage_client.bucket(self.bucket_name)
 
     def reader(self, object_name: str) -> BlobReader:

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -99,8 +99,8 @@ class DataFluxIterableDataset(data.IterableDataset):
         if not storage_client:
             self.storage_client = storage.Client(
                 project=project_name,
-                client_info=ClientInfo(user_agent="dataflux/0.0"),
             )
+        dataflux_core.user_agent.add_dataflux_user_agent(self.storage_client)
         self.project_name = project_name
         self.bucket_name = bucket_name
         self.data_format_fn = data_format_fn
@@ -153,13 +153,15 @@ class DataFluxIterableDataset(data.IterableDataset):
         listed_objects = []
         for _ in range(self.config.max_listing_retries):
             try:
-                listed_objects = dataflux_core.fast_list.ListingController(
+                lister = dataflux_core.fast_list.ListingController(
                     max_parallelism=self.config.num_processes,
                     project=self.project_name,
                     bucket=self.bucket_name,
                     sort_results=self.config.sort_listing_results,
                     prefix=self.config.prefix,
-                ).run()
+                )
+                lister.client = self.storage_client
+                listed_objects = lister.run()
             except Exception as e:
                 logging.error(
                     f"exception {str(e)} caught running Dataflux fast listing."

--- a/dataflux_pytorch/tests/test_dataflux_checkpoint.py
+++ b/dataflux_pytorch/tests/test_dataflux_checkpoint.py
@@ -38,10 +38,14 @@ class CheckpointTestCase(unittest.TestCase):
     def test_reader(self):
         got_reader = self.ckpt.reader(self.object_name)
         self.assertIsInstance(got_reader, io.BytesIO)
+        self.assertTrue(
+            self.ckpt.storage_client._connection.user_agent.startswith("dataflux"))
 
     def test_writer(self):
         got_writer = self.ckpt.writer(self.object_name)
         self.assertIsInstance(got_writer, fake_gcs.FakeBlobWriter)
+        self.assertTrue(
+            self.ckpt.storage_client._connection.user_agent.startswith("dataflux"))
 
 
 if __name__ == "__main__":

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -14,21 +14,25 @@
  limitations under the License.
  """
 
+import math
 import unittest
 from unittest import mock
-import math
 
 from dataflux_client_python.dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_iterable_dataset
 
 
 class IterableDatasetTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.project_name = "foo"
         self.bucket_name = "bar"
         self.config = dataflux_iterable_dataset.Config(
-            num_processes=3, max_listing_retries=3, prefix="", sort_listing_results=True,
+            num_processes=3,
+            max_listing_retries=3,
+            prefix="",
+            sort_listing_results=True,
         )
         self.data_format_fn = lambda data: data
         client = fake_gcs.Client()
@@ -45,8 +49,7 @@ class IterableDatasetTestCase(unittest.TestCase):
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act.
         ds = dataflux_iterable_dataset.DataFluxIterableDataset(
@@ -71,8 +74,7 @@ class IterableDatasetTestCase(unittest.TestCase):
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act.
         ds = dataflux_iterable_dataset.DataFluxIterableDataset(
@@ -104,8 +106,7 @@ class IterableDatasetTestCase(unittest.TestCase):
             Exception(),
         ]
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act.
         ds = dataflux_iterable_dataset.DataFluxIterableDataset(
@@ -124,7 +125,8 @@ class IterableDatasetTestCase(unittest.TestCase):
         )
 
     @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
-    def test_init_raises_exception_when_retries_exhaust(self, mock_dataflux_core):
+    def test_init_raises_exception_when_retries_exhaust(
+            self, mock_dataflux_core):
         """Tests that the initialization raises exception upon exhaustive retries."""
         # Arrange.
         mock_listing_controller = mock.Mock()
@@ -135,8 +137,7 @@ class IterableDatasetTestCase(unittest.TestCase):
             want_exception for _ in range(self.config.max_listing_retries)
         ]
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act & Assert.
         with self.assertRaises(RuntimeError) as re:
@@ -166,23 +167,22 @@ class IterableDatasetTestCase(unittest.TestCase):
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
         want_optimization_params = object()
         mock_dataflux_core.download.DataFluxDownloadOptimizationParams.return_value = (
-            want_optimization_params
-        )
+            want_optimization_params)
         dataflux_download_return_val = [
             bytes("contentA", "utf-8"),
             bytes("contentBB", "utf-8"),
         ]
 
         mock_dataflux_core.download.dataflux_download_lazy.return_value = iter(
-            dataflux_download_return_val
-        )
+            dataflux_download_return_val)
         mock_worker_info.return_value = None
 
-        def data_format_fn(content): return len(content)
+        def data_format_fn(content):
+            return len(content)
+
         want_downloaded = [
             data_format_fn(bytes_content)
             for bytes_content in dataflux_download_return_val
@@ -217,31 +217,29 @@ class IterableDatasetTestCase(unittest.TestCase):
 
     @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
     @mock.patch("torch.utils.data.get_worker_info")
-    def test_iter_multiple_processes(self, mock_worker_info, mock_dataflux_core):
+    def test_iter_multiple_processes(self, mock_worker_info,
+                                     mock_dataflux_core):
         """
         Tests that the using the iterator of the dataset downloads the list of the correct objects with a multi-process setup.
         Specifically, each worker should be assigned to download a different batch of the dataset.
         """
         # Arrange.
-        want_objects = [("objectA", 1), ("objectB", 2),
-                        ("objectC", 3), ("objectD", 4)]
+        want_objects = [("objectA", 1), ("objectB", 2), ("objectC", 3),
+                        ("objectD", 4)]
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
         want_optimization_params = object()
         mock_dataflux_core.download.DataFluxDownloadOptimizationParams.return_value = (
-            want_optimization_params
-        )
+            want_optimization_params)
         dataflux_download_return_val = [
             bytes("contentA", "utf-8"),
             bytes("contentBB", "utf-8"),
         ]
 
         mock_dataflux_core.download.dataflux_download_lazy.return_value = iter(
-            dataflux_download_return_val
-        )
+            dataflux_download_return_val)
 
         class _WorkerInfo:
             """A fake WorkerInfo class for testing purpose."""
@@ -258,7 +256,9 @@ class IterableDatasetTestCase(unittest.TestCase):
         worker_info = _WorkerInfo(num_workers=num_workers, id=id)
         mock_worker_info.return_value = worker_info
 
-        def data_format_fn(content): return len(content)
+        def data_format_fn(content):
+            return len(content)
+
         want_downloaded = [
             data_format_fn(bytes_content)
             for bytes_content in dataflux_download_return_val

--- a/dataflux_pytorch/tests/test_dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/tests/test_dataflux_lightning_checkpoint.py
@@ -1,12 +1,15 @@
-import torch
 import unittest
+from typing import Any, Dict
 
-from typing import Dict, Any
+import torch
+
 from dataflux_client_python.dataflux_core.tests import fake_gcs
-from dataflux_pytorch.lightning.dataflux_lightning_checkpoint import DatafluxLightningCheckpoint
+from dataflux_pytorch.lightning.dataflux_lightning_checkpoint import \
+    DatafluxLightningCheckpoint
 
 
 class LightningCheckpointTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.project_name = "foo"
@@ -58,11 +61,13 @@ class LightningCheckpointTestCase(unittest.TestCase):
         except:
             return
         self.fail(
-            "Attempted to save to a path with an unexpect bucket, expects this to fail")
+            "Attempted to save to a path with an unexpect bucket, expects this to fail"
+        )
 
     def test_valid_path(self):
-        paths = {f'gs://{self.bucket_name}/path',
-                 f'gcs://{self.bucket_name}/path'}
+        paths = {
+            f'gs://{self.bucket_name}/path', f'gcs://{self.bucket_name}/path'
+        }
         for p in paths:
             try:
                 self.ckpt._parse_gcs_path(p)
@@ -76,7 +81,8 @@ class LightningCheckpointTestCase(unittest.TestCase):
         loaded_checkpoint = self.ckpt.load_checkpoint(ckpt_path)
         assert torch.equal(tensor, loaded_checkpoint)
         self.assertTrue(
-            self.ckpt.storage_client._connection.user_agent.startswith("dataflux"))
+            self.ckpt.storage_client._connection.user_agent.startswith(
+                "dataflux"))
 
     def test_delete_checkpoint(self):
         tensor = torch.rand(3, 10, 10)

--- a/dataflux_pytorch/tests/test_dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/tests/test_dataflux_lightning_checkpoint.py
@@ -5,8 +5,9 @@ from typing import Dict, Any
 from dataflux_client_python.dataflux_core.tests import fake_gcs
 from dataflux_pytorch.lightning.dataflux_lightning_checkpoint import DatafluxLightningCheckpoint
 
+
 class LightningCheckpointTestCase(unittest.TestCase):
-  def setUp(self):
+    def setUp(self):
         super().setUp()
         self.project_name = "foo"
         self.bucket_name = "fake_bucket"
@@ -18,68 +19,72 @@ class LightningCheckpointTestCase(unittest.TestCase):
             bucket_name=self.bucket_name,
             storage_client=client,
         )
-        self.bucket=fake_gcs.Bucket("fake_bucket")
+        self.bucket = fake_gcs.Bucket("fake_bucket")
 
-  def test_invalid_path_save(self):
-      ckpt_path = "fake_bucket/checkpoint.ckpt"
-      try:
-          self.ckpt.save_checkpoint(None, ckpt_path)
-      except:
-          return
-      self.fail("Saving with an invalid path did not fail")
-
-  def test_invalid_path_load(self):
-      ckpt_path = "fake_bucket/checkpoint.ckpt"
-      try:
-          self.ckpt.load_checkpoint(ckpt_path)
-      except:
-          return
-      self.fail("Loading with an invalid path did not fail")
-
-  def test_invalid_path_remove(self):
-      ckpt_path = "fake_bucket/checkpoint.ckpt"
-      try:
-          self.ckpt.remove_checkpoint(ckpt_path)
-      except:
-          return
-      self.fail("Removing an invalid path did not fail")
-
-  def test_empty_bucket_name(self):
-      try:
-        self.ckpt._parse_gcs_path("gcs://")
-      except:
-          return
-      self.fail("Empty bucket name expected to fail when parsed")
-
-  def test_invalid_bucket_name(self):
-      try:
-        self.ckpt._parse_gcs_path("gcs://invalid_bucket/ckpt.ckpt")
-      except:
-          return
-      self.fail("Attempted to save to a path with an unexpect bucket, expects this to fail")
-
-  def test_valid_path(self):
-      paths = {f'gs://{self.bucket_name}/path', f'gcs://{self.bucket_name}/path'}
-      for p in paths:
+    def test_invalid_path_save(self):
+        ckpt_path = "fake_bucket/checkpoint.ckpt"
         try:
-          self.ckpt._parse_gcs_path(p)
+            self.ckpt.save_checkpoint(None, ckpt_path)
         except:
-          self.fail(msg=f'Valid path: {p} parsed but failed')
+            return
+        self.fail("Saving with an invalid path did not fail")
 
-  def test_save_and_load_checkpoint(self):
-      tensor = torch.rand(3, 10, 10)
-      ckpt_path = "gcs://fake_bucket/checkpoint.ckpt"
-      self.ckpt.save_checkpoint(tensor, ckpt_path)
-      loaded_checkpoint = self.ckpt.load_checkpoint(ckpt_path)
-      assert torch.equal(tensor, loaded_checkpoint)
+    def test_invalid_path_load(self):
+        ckpt_path = "fake_bucket/checkpoint.ckpt"
+        try:
+            self.ckpt.load_checkpoint(ckpt_path)
+        except:
+            return
+        self.fail("Loading with an invalid path did not fail")
 
-  def test_delete_checkpoint(self):
-      tensor = torch.rand(3, 10, 10)
-      ckpt_path = "gcs://fake_bucket/checkpoint.ckpt"
-      self.ckpt.save_checkpoint(tensor, ckpt_path)
-      loaded_checkpoint = self.ckpt.load_checkpoint(ckpt_path)
-      assert torch.equal(tensor, loaded_checkpoint)
-      self.ckpt.remove_checkpoint(ckpt_path)
+    def test_invalid_path_remove(self):
+        ckpt_path = "fake_bucket/checkpoint.ckpt"
+        try:
+            self.ckpt.remove_checkpoint(ckpt_path)
+        except:
+            return
+        self.fail("Removing an invalid path did not fail")
+
+    def test_empty_bucket_name(self):
+        try:
+            self.ckpt._parse_gcs_path("gcs://")
+        except:
+            return
+        self.fail("Empty bucket name expected to fail when parsed")
+
+    def test_invalid_bucket_name(self):
+        try:
+            self.ckpt._parse_gcs_path("gcs://invalid_bucket/ckpt.ckpt")
+        except:
+            return
+        self.fail(
+            "Attempted to save to a path with an unexpect bucket, expects this to fail")
+
+    def test_valid_path(self):
+        paths = {f'gs://{self.bucket_name}/path',
+                 f'gcs://{self.bucket_name}/path'}
+        for p in paths:
+            try:
+                self.ckpt._parse_gcs_path(p)
+            except:
+                self.fail(msg=f'Valid path: {p} parsed but failed')
+
+    def test_save_and_load_checkpoint(self):
+        tensor = torch.rand(3, 10, 10)
+        ckpt_path = "gcs://fake_bucket/checkpoint.ckpt"
+        self.ckpt.save_checkpoint(tensor, ckpt_path)
+        loaded_checkpoint = self.ckpt.load_checkpoint(ckpt_path)
+        assert torch.equal(tensor, loaded_checkpoint)
+        self.assertTrue(
+            self.ckpt.storage_client._connection.user_agent.startswith("dataflux"))
+
+    def test_delete_checkpoint(self):
+        tensor = torch.rand(3, 10, 10)
+        ckpt_path = "gcs://fake_bucket/checkpoint.ckpt"
+        self.ckpt.save_checkpoint(tensor, ckpt_path)
+        loaded_checkpoint = self.ckpt.load_checkpoint(ckpt_path)
+        assert torch.equal(tensor, loaded_checkpoint)
+        self.ckpt.remove_checkpoint(ckpt_path)
 
 
 if __name__ == "__main__":

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -22,13 +22,16 @@ from dataflux_pytorch import dataflux_mapstyle_dataset
 
 
 class ListingTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.project_name = "foo"
         self.bucket_name = "bar"
         self.config = dataflux_mapstyle_dataset.Config(
-            num_processes=3, max_listing_retries=3, prefix="", sort_listing_results=True
-        )
+            num_processes=3,
+            max_listing_retries=3,
+            prefix="",
+            sort_listing_results=True)
         self.data_format_fn = lambda data: data
         client = fake_gcs.Client()
 
@@ -45,8 +48,7 @@ class ListingTestCase(unittest.TestCase):
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -71,8 +73,7 @@ class ListingTestCase(unittest.TestCase):
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -104,8 +105,7 @@ class ListingTestCase(unittest.TestCase):
             Exception(),
         ]
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -124,7 +124,8 @@ class ListingTestCase(unittest.TestCase):
         )
 
     @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
-    def test_init_raises_exception_when_retries_exhaust(self, mock_dataflux_core):
+    def test_init_raises_exception_when_retries_exhaust(
+            self, mock_dataflux_core):
         """Tests that the initialization raises exception upon exhaustive retries."""
         # Arrange.
         mock_listing_controller = mock.Mock()
@@ -135,8 +136,7 @@ class ListingTestCase(unittest.TestCase):
             want_exception for _ in range(self.config.max_listing_retries)
         ]
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act & Assert.
         with self.assertRaises(RuntimeError) as re:
@@ -165,8 +165,7 @@ class ListingTestCase(unittest.TestCase):
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -191,8 +190,7 @@ class ListingTestCase(unittest.TestCase):
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = sorted(self.want_objects)
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
         want_downloaded = bytes("content", "utf-8")
         mock_dataflux_core.download.download_single.return_value = want_downloaded
         want_idx = 0
@@ -225,20 +223,20 @@ class ListingTestCase(unittest.TestCase):
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller
-        )
+            mock_listing_controller)
         want_optimization_params = object()
         mock_dataflux_core.download.DataFluxDownloadOptimizationParams.return_value = (
-            want_optimization_params
-        )
+            want_optimization_params)
         dataflux_download_return_val = [
             bytes("contentA", "utf-8"),
             bytes("contentBB", "utf-8"),
         ]
         mock_dataflux_core.download.dataflux_download_threaded.return_value = (
-            dataflux_download_return_val
-        )
-        def data_format_fn(content): return len(content)
+            dataflux_download_return_val)
+
+        def data_format_fn(content):
+            return len(content)
+
         want_downloaded = [
             data_format_fn(bytes_content)
             for bytes_content in dataflux_download_return_val


### PR DESCRIPTION
This ensures that we only have to update the version in one place when it changes, and the user agent gets set even for existing storage client objects.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR