### PR TITLE
Refactor Dataflux simple demo loops and add retry flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+# Base Image: Start with a slim Python image that already includes Python3.
+FROM pytorch/pytorch:2.3.1-cuda11.8-cudnn8-devel
+
+# Set Working Directory.
+WORKDIR /app
+
+# Copy the Python training code and the requirements.txt file.
+COPY ./ ./
+
+RUN pip install .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-# Base Image: Start with a slim Python image that already includes Python3.
+# Base Image: Start with an image that already includes PyTorch and Cuda.
 FROM pytorch/pytorch:2.3.1-cuda11.8-cudnn8-devel
 
 # Set Working Directory.
 WORKDIR /app
 
-# Copy the Python training code and the requirements.txt file.
+# Copy the code.
 COPY ./ ./
 
 RUN pip install .

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ We tested the Map-style Dataset's early performance using [DLIO benchmark](https
 </table>
 
 ### Iterable-style Dataset
-Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesn’t easily support an implementation of a PyTorch iterable dataset, we implemented a [simple training loop](demo/simple_iterable_dataset.py) that has similar IO behaviors as the DLIO benchmark and used that loop to benchmark the Iterable Datasets.
+Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesn’t easily support an implementation of a PyTorch iterable dataset, we implemented a [simple training loop](demo/list-and-download/iterable/simple_iterable_dataset.py) that has similar IO behaviors as the DLIO benchmark and used that loop to benchmark the Iterable Datasets.
 
 <table>
   <tr>

--- a/demo/list-and-download/README.md
+++ b/demo/list-and-download/README.md
@@ -1,0 +1,33 @@
+# Demo loops
+
+## Running locally
+
+### Run the map-style loop
+
+1. `python3 -m demo.list-and-download.map.simple_map_style_dataset --project=gcs-tess --bucket=bernardhan-diffusion-small --sleep-per-step=0 --num-workers=48 --epochs=2`
+
+### Run the iterable-style loop
+
+1. `python3 -m demo.list-and-download.iterable.simple_iterable_dataset --project=gcs-tess --bucket=bernardhan-diffusion-small --sleep-per-step=0 --num-workers=48 --epochs=2`
+
+## Running on GKE
+
+### Build the Docker image
+
+In the following commands, update `gcs-tess` to your project ID as needed.
+
+1. `docker build -t dataflux-list-and-download .`
+2. `docker tag dataflux-list-and-download gcr.io/gcs-tess/dataflux-list-and-download`
+3. `docker push gcr.io/gcs-tess/dataflux-list-and-download`
+
+### Run the map-style loop
+
+1. Update any needed flags/configs in `demo/list-and-download/map/deployment.yaml`
+    * Notably the job name, completions/parallelism, image name, and any flags
+2. `kubectl apply -f demo/list-and-download/map/deployment.yaml`
+
+### Run the iterable-style loop
+
+1. Update any needed flags/configs in `demo/list-and-download/iterable/deployment.yaml`
+    * Notably the job name, completions/parallelism, image name, and any flags
+2. `kubectl apply -f demo/list-and-download/iterable/deployment.yaml`

--- a/demo/list-and-download/iterable/deployment.yaml
+++ b/demo/list-and-download/iterable/deployment.yaml
@@ -1,0 +1,55 @@
+# GKE deployment script for the Dataflux container.
+# If you push a new version of the container, you need to update the image.
+# You can set the environment variables from main.go to control the flags.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mirvine-dataflux
+  namespace: default
+spec:
+  backoffLimit: 6
+  completionMode: NonIndexed
+  completions: 100
+  manualSelector: false
+  parallelism: 100
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+  suspend: false
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        batch.kubernetes.io/job-name: mirvine-dataflux
+        job-name: mirvine-dataflux
+    spec:
+      containers:
+      - image: gcr.io/gcs-tess/dataflux-list-and-download:latest
+        imagePullPolicy: Always
+        name: dataflux-list-and-download-sha256-1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -x;
+
+              echo "running the training code";
+              cd /app ;
+              python3 -u -m demo.list-and-download.iterable.simple_iterable_dataset --project=gcs-tess --bucket=tessellations-datasets --prefix=UNet3D/medium/3MB-150GB --sleep-per-step=0 --num-workers=32  --prefetch-factor=5 --epochs=2 --batch-size=128 --retry-timeout=100000 --retry-multiplier="1.5" --retry-maximum="30"
+              ex=$?
+              sleep 60
+              exit ${ex}
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            job-name: mirvine-dataflux

--- a/demo/list-and-download/iterable/deployment.yaml
+++ b/demo/list-and-download/iterable/deployment.yaml
@@ -7,9 +7,9 @@ metadata:
 spec:
   backoffLimit: 6
   completionMode: NonIndexed
-  completions: 100
+  completions: 1000
   manualSelector: false
-  parallelism: 100
+  parallelism: 1000
   podReplacementPolicy: TerminatingOrFailed
   selector:
   suspend: false

--- a/demo/list-and-download/iterable/deployment.yaml
+++ b/demo/list-and-download/iterable/deployment.yaml
@@ -1,6 +1,4 @@
-# GKE deployment script for the Dataflux container.
-# If you push a new version of the container, you need to update the image.
-# You can set the environment variables from main.go to control the flags.
+# GKE deployment script for the Dataflux iterable-style demo loop.
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/demo/list-and-download/iterable/simple_iterable_dataset.py
+++ b/demo/list-and-download/iterable/simple_iterable_dataset.py
@@ -42,7 +42,7 @@ def parse_args():
 Sample training loop that utilizes the Dataflux Iterable Dataset, iterates over the given bucket and
 counts the number of objects/bytes. For example:
 
-$ python3 -m demo.simple_iterable_dataset --project=<YOUR_PROJECT> --bucket=<YOUR_BUCKET> --prefix=<YOUR_PREFIX> --epochs=2 --num-workers=8
+$ python3 -m demo.list-and-download.iterable.simple_iterable_dataset --project=<YOUR_PROJECT> --bucket=<YOUR_BUCKET> --prefix=<YOUR_PREFIX> --epochs=2 --num-workers=8
 
 You can also use the --no-dataflux flag to override the configuration so that listing
 is done sequentially and objects are downloaded individually, allowing you to compare

--- a/demo/list-and-download/map/README.md
+++ b/demo/list-and-download/map/README.md
@@ -1,8 +1,0 @@
-# Map-style demo loop
-
-## Running on GKE
-
-1. `docker build -t dataflux-list-and-download .`
-2. `docker tag dataflux-list-and-download gcr.io/gcs-tess/dataflux-list-and-download`
-3. `docker push gcr.io/gcs-tess/dataflux-list-and-download`
-4. `kubectl apply -f demo/list-and-download/map/deployment.yaml`

--- a/demo/list-and-download/map/README.md
+++ b/demo/list-and-download/map/README.md
@@ -1,0 +1,8 @@
+# Map-style demo loop
+
+## Running on GKE
+
+1. `docker build -t dataflux-list-and-download .`
+2. `docker tag dataflux-list-and-download gcr.io/gcs-tess/dataflux-list-and-download`
+3. `docker push gcr.io/gcs-tess/dataflux-list-and-download`
+4. `kubectl apply -f demo/list-and-download/map/deployment.yaml`

--- a/demo/list-and-download/map/deployment.yaml
+++ b/demo/list-and-download/map/deployment.yaml
@@ -37,7 +37,7 @@ spec:
 
               echo "running the training code";
               cd /app ;
-              python3 -u -m demo.list-and-download.map.simple_map_style_dataset --project=gcs-tess --bucket=tessellations-datasets --prefix=UNet3D/medium/3MB-150GB --sleep-per-step=0 --num-workers=32  --prefetch-factor=5 --epochs=2 --batch-size=128
+              python3 -u -m demo.list-and-download.map.simple_map_style_dataset --project=gcs-tess --bucket=tessellations-datasets --prefix=UNet3D/medium/3MB-150GB --sleep-per-step=0 --num-workers=32  --prefetch-factor=5 --epochs=2 --batch-size=128 --retry-timeout=100000 --retry-multiplier="1.5" --retry-maximum="30"
               ex=$?
               sleep 60
               exit ${ex}

--- a/demo/list-and-download/map/deployment.yaml
+++ b/demo/list-and-download/map/deployment.yaml
@@ -1,0 +1,55 @@
+# GKE deployment script for the Dataflux container.
+# If you push a new version of the container, you need to update the image.
+# You can set the environment variables from main.go to control the flags.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: mirvine-dataflux
+  namespace: default
+spec:
+  backoffLimit: 6
+  completionMode: NonIndexed
+  completions: 1000
+  manualSelector: false
+  parallelism: 1000
+  podReplacementPolicy: TerminatingOrFailed
+  selector:
+  suspend: false
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        batch.kubernetes.io/job-name: mirvine-dataflux
+        job-name: mirvine-dataflux
+    spec:
+      containers:
+      - image: gcr.io/gcs-tess/dataflux-list-and-download:latest
+        imagePullPolicy: Always
+        name: dataflux-list-and-download-sha256-1
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: FallbackToLogsOnError
+        command:
+            - "/bin/bash"
+            - "-c"
+            - |
+              set -x;
+
+              echo "running the training code";
+              cd /app ;
+              python3 -u -m demo.list-and-download.map.simple_map_style_dataset --project=gcs-tess --bucket=tessellations-datasets --prefix=UNet3D/medium/3MB-150GB --sleep-per-step=0 --num-workers=32  --prefetch-factor=5 --epochs=2 --batch-size=128
+              ex=$?
+              sleep 60
+              exit ${ex}
+      dnsPolicy: ClusterFirst
+      restartPolicy: OnFailure
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+      topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            job-name: mirvine-dataflux

--- a/demo/list-and-download/map/deployment.yaml
+++ b/demo/list-and-download/map/deployment.yaml
@@ -1,6 +1,4 @@
-# GKE deployment script for the Dataflux container.
-# If you push a new version of the container, you need to update the image.
-# You can set the environment variables from main.go to control the flags.
+# GKE deployment script for the Dataflux map-style demo loop.
 apiVersion: batch/v1
 kind: Job
 metadata:


### PR DESCRIPTION
A few things in this PR:

* Add retry flags to the demo loop code now that it's configurable
* Add a base-level Dockerfile to containerize the whole repo for testing on GKE
* Restructure the demos and give them GKE deployment files, along with a README
* Other minor fixes in the demo loops

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR