### PR TITLE
Update default retry config to match successful 1k-node benchmarks.

### DIFF
--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -20,13 +20,12 @@ import os
 
 import dataflux_core
 from google.api_core.client_info import ClientInfo
-from google.cloud.storage.retry import DEFAULT_RETRY
 from google.cloud import storage
+from google.cloud.storage.retry import DEFAULT_RETRY
 from torch.utils import data
 
-MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(300.0).with_delay(initial=1.0,
-                                                               multiplier=1.2,
-                                                               maximum=45.0)
+MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(100000.0).with_delay(
+    initial=1.0, multiplier=1.5, maximum=30.0)
 
 
 class Config:

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -23,9 +23,8 @@ from google.cloud import storage
 from google.cloud.storage.retry import DEFAULT_RETRY
 from torch.utils import data
 
-MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(300.0).with_delay(initial=1.0,
-                                                               multiplier=1.2,
-                                                               maximum=45.0)
+MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(100000.0).with_delay(
+    initial=1.0, multiplier=1.5, maximum=30.0)
 
 
 class Config:


### PR DESCRIPTION
These match the configs used in the demo/list-and-download benchmarks that I ran successfully. It ensures that retriable errors do not cause the entire job to fail while being retried, even if there's high load. 

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR