### PR TITLE
For mac and windows skip passing client storage to avoid pickling error in multiprocessing

### DIFF
--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -16,8 +16,8 @@
 
 import logging
 import math
+import multiprocessing
 import os
-import platform
 import warnings
 
 import dataflux_core
@@ -29,8 +29,7 @@ from torch.utils import data
 MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(100000.0).with_delay(
     initial=1.0, multiplier=1.5, maximum=30.0)
 
-OS = platform.system()
-LINUX = "Linux"
+FORK = "fork"
 
 
 class Config:
@@ -87,7 +86,7 @@ class Config:
         self.download_retry_config = download_retry_config
 
 
-def data_format_default(self, data):
+def data_format_default(data):
     return data
 
 
@@ -120,9 +119,11 @@ class DataFluxIterableDataset(data.IterableDataset):
                 during initialization.
         """
         super().__init__()
-        if storage_client is not None and OS != LINUX:
+        multiprocessing_start = multiprocessing.get_start_method(
+            allow_none=False)
+        if storage_client is not None and multiprocessing_start != FORK:
             warnings.warn(
-                "Setting the storage client is not fully supported on non-Linux platforms.",
+                "Setting the storage client is not fully supported when multiprocessing starts with spawn or forkserver methods.",
                 UserWarning)
         self.storage_client = storage_client
         self.project_name = project_name

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -17,6 +17,7 @@
 import logging
 import math
 import os
+import platform
 
 import dataflux_core
 from google.api_core.client_info import ClientInfo
@@ -25,7 +26,11 @@ from google.cloud.storage.retry import DEFAULT_RETRY
 from torch.utils import data
 
 MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(100000.0).with_delay(
-    initial=1.0, multiplier=1.5, maximum=30.0)
+    initial=1.0, multiplier=1.5, maximum=30.0
+)
+
+OS = platform.system()
+LINUX = "Linux"
 
 
 class Config:
@@ -66,10 +71,8 @@ class Config:
         prefix: str = None,
         max_listing_retries: int = 3,
         disable_compose: bool = False,
-        list_retry_config:
-        "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
-        download_retry_config:
-        "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
+        list_retry_config: "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
+        download_retry_config: "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
     ):
         self.sort_listing_results = sort_listing_results
         self.max_composite_object_size = max_composite_object_size
@@ -89,7 +92,7 @@ class DataFluxIterableDataset(data.IterableDataset):
         project_name,
         bucket_name,
         config=Config(),
-        data_format_fn=lambda data: data,
+        data_format_fn=None,
         storage_client=None,
     ):
         """Initializes the DataFluxIterableDataset.
@@ -111,18 +114,25 @@ class DataFluxIterableDataset(data.IterableDataset):
                 during initialization.
         """
         super().__init__()
-        self.storage_client = storage_client
-        if not storage_client:
-            self.storage_client = storage.Client(project=project_name, )
-        dataflux_core.user_agent.add_dataflux_user_agent(self.storage_client)
+        self.storage_client = None
+        if OS == LINUX:
+            self.storage_client = (
+                storage_client
+                if storage_client is not None
+                else storage.Client(project=project_name)
+            )
+            dataflux_core.user_agent.add_dataflux_user_agent(self.storage_client)
         self.project_name = project_name
         self.bucket_name = bucket_name
-        self.data_format_fn = data_format_fn
+        self.data_format_fn = (
+            data_format_fn if data_format_fn is not None else self.data_format_default
+        )
         self.config = config
         self.dataflux_download_optimization_params = (
             dataflux_core.download.DataFluxDownloadOptimizationParams(
                 max_composite_object_size=self.config.max_composite_object_size
-            ))
+            )
+        )
 
         self.objects = self._list_GCS_blobs_with_retry()
 
@@ -130,34 +140,40 @@ class DataFluxIterableDataset(data.IterableDataset):
         worker_info = data.get_worker_info()
         if worker_info is None:
             # Single-process data loading.
-            yield from (self.data_format_fn(bytes_content) for bytes_content in
-                        dataflux_core.download.dataflux_download_lazy(
-                            project_name=self.project_name,
-                            bucket_name=self.bucket_name,
-                            objects=self.objects,
-                            storage_client=self.storage_client,
-                            dataflux_download_optimization_params=self.
-                            dataflux_download_optimization_params,
-                            retry_config=self.config.download_retry_config,
-                        ))
+            yield from (
+                self.data_format_fn(bytes_content)
+                for bytes_content in dataflux_core.download.dataflux_download_lazy(
+                    project_name=self.project_name,
+                    bucket_name=self.bucket_name,
+                    objects=self.objects,
+                    storage_client=self.storage_client,
+                    dataflux_download_optimization_params=self.dataflux_download_optimization_params,
+                    retry_config=self.config.download_retry_config,
+                )
+            )
         else:
             # Multi-process data loading. Split the workload among workers.
             # Ref: https://pytorch.org/docs/stable/data.html#torch.utils.data.IterableDataset.
             per_worker = int(
-                math.ceil(len(self.objects) / float(worker_info.num_workers)))
+                math.ceil(len(self.objects) / float(worker_info.num_workers))
+            )
             worker_id = worker_info.id
             start = worker_id * per_worker
             end = min(start + per_worker, len(self.objects))
-            yield from (self.data_format_fn(bytes_content) for bytes_content in
-                        dataflux_core.download.dataflux_download_lazy(
-                            project_name=self.project_name,
-                            bucket_name=self.bucket_name,
-                            objects=self.objects[start:end],
-                            storage_client=self.storage_client,
-                            dataflux_download_optimization_params=self.
-                            dataflux_download_optimization_params,
-                            retry_config=self.config.download_retry_config,
-                        ))
+            yield from (
+                self.data_format_fn(bytes_content)
+                for bytes_content in dataflux_core.download.dataflux_download_lazy(
+                    project_name=self.project_name,
+                    bucket_name=self.bucket_name,
+                    objects=self.objects[start:end],
+                    storage_client=self.storage_client,
+                    dataflux_download_optimization_params=self.dataflux_download_optimization_params,
+                    retry_config=self.config.download_retry_config,
+                )
+            )
+
+    def data_format_default(self, data):
+        return data
 
     def _list_GCS_blobs_with_retry(self):
         """Retries Dataflux Listing upon exceptions, up to the retries defined in self.config."""

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -312,7 +312,7 @@ class IterableDatasetTestCase(unittest.TestCase):
             f"got listed objects {ds.objects}, want {self.want_objects}",
         )
 
-    def test_init_with_spaw_multiprocess(self):
+    def test_init_with_spawn_multiprocess(self):
         """Tests the DataFluxIterableDataset returns pickling error for passing-in client when multiprcessing start method is spawn."""
         # Act.
         client = storage.Client(project=self.project_name)

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -20,7 +20,7 @@ import pickle
 import unittest
 from unittest import mock
 
-from dataflux_core.tests import fake_gcs
+from dataflux_client_python.dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_iterable_dataset
 from google.cloud import storage
 

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -15,11 +15,14 @@
  """
 
 import math
+import multiprocessing
+import pickle
 import unittest
 from unittest import mock
 
 from dataflux_client_python.dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_iterable_dataset
+from google.cloud import storage
 
 
 class IterableDatasetTestCase(unittest.TestCase):
@@ -309,6 +312,20 @@ class IterableDatasetTestCase(unittest.TestCase):
             f"got listed objects {ds.objects}, want {self.want_objects}",
         )
 
+    def test_init_with_spaw_multiprocess(self):
+        """Tests the DataFluxIterableDataset returns pickling error for passing-in client when multiprcessing start method is spawn."""
+        # Act.
+        client = storage.Client(project=self.project_name)
+        with self.assertRaises(pickle.PicklingError):
+            dataflux_iterable_dataset.DataFluxIterableDataset(
+                project_name=self.project_name,
+                bucket_name=self.bucket_name,
+                config=self.config,
+                data_format_fn=self.data_format_fn,
+                storage_client=client,
+            )
+
 
 if __name__ == "__main__":
+    multiprocessing.set_start_method("spawn")
     unittest.main()

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -20,7 +20,7 @@ import pickle
 import unittest
 from unittest import mock
 
-from dataflux_client_python.dataflux_core.tests import fake_gcs
+from dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_iterable_dataset
 from google.cloud import storage
 
@@ -316,14 +316,15 @@ class IterableDatasetTestCase(unittest.TestCase):
         """Tests the DataFluxIterableDataset returns pickling error for passing-in client when multiprcessing start method is spawn."""
         # Act.
         client = storage.Client(project=self.project_name)
-        with self.assertRaises(pickle.PicklingError):
-            dataflux_iterable_dataset.DataFluxIterableDataset(
-                project_name=self.project_name,
-                bucket_name=self.bucket_name,
-                config=self.config,
-                data_format_fn=self.data_format_fn,
-                storage_client=client,
-            )
+        if multiprocessing.get_start_method(allow_none=False) != "fork":
+            with self.assertRaises(pickle.PicklingError):
+                dataflux_iterable_dataset.DataFluxIterableDataset(
+                    project_name=self.project_name,
+                    bucket_name=self.bucket_name,
+                    config=self.config,
+                    data_format_fn=self.data_format_fn,
+                    storage_client=client,
+                )
 
 
 if __name__ == "__main__":

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -14,11 +14,14 @@
  limitations under the License.
  """
 
+import pickle
+import multiprocessing
 import unittest
 from unittest import mock
 
 from dataflux_client_python.dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_mapstyle_dataset
+from google.cloud import storage
 
 
 class ListingTestCase(unittest.TestCase):
@@ -285,6 +288,20 @@ class ListingTestCase(unittest.TestCase):
             f"got listed objects {ds.objects}, want {self.want_objects}",
         )
 
+    def test_init_with_spaw_multiprocess(self):
+        """Tests the DataFluxIterableDataset returns pickling error for passing-in client when multiprcessing start method is spawn."""
+        # Act.
+        client = storage.Client(project=self.project_name)
+        with self.assertRaises(pickle.PicklingError):
+            dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
+                project_name=self.project_name,
+                bucket_name=self.bucket_name,
+                config=self.config,
+                data_format_fn=self.data_format_fn,
+                storage_client=client,
+            )
+
 
 if __name__ == "__main__":
+    multiprocessing.set_start_method("spawn")
     unittest.main()

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -288,7 +288,7 @@ class ListingTestCase(unittest.TestCase):
             f"got listed objects {ds.objects}, want {self.want_objects}",
         )
 
-    def test_init_with_spaw_multiprocess(self):
+    def test_init_with_spawn_multiprocess(self):
         """Tests the DataFluxIterableDataset returns pickling error for passing-in client when multiprcessing start method is spawn."""
         # Act.
         client = storage.Client(project=self.project_name)

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -19,7 +19,7 @@ import multiprocessing
 import unittest
 from unittest import mock
 
-from dataflux_core.tests import fake_gcs
+from dataflux_client_python.dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_mapstyle_dataset
 from google.cloud import storage
 

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -19,7 +19,7 @@ import multiprocessing
 import unittest
 from unittest import mock
 
-from dataflux_client_python.dataflux_core.tests import fake_gcs
+from dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_mapstyle_dataset
 from google.cloud import storage
 
@@ -292,14 +292,15 @@ class ListingTestCase(unittest.TestCase):
         """Tests the DataFluxIterableDataset returns pickling error for passing-in client when multiprcessing start method is spawn."""
         # Act.
         client = storage.Client(project=self.project_name)
-        with self.assertRaises(pickle.PicklingError):
-            dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
-                project_name=self.project_name,
-                bucket_name=self.bucket_name,
-                config=self.config,
-                data_format_fn=self.data_format_fn,
-                storage_client=client,
-            )
+        if multiprocessing.get_start_method(allow_none=False) != "fork":
+            with self.assertRaises(pickle.PicklingError):
+                dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
+                    project_name=self.project_name,
+                    bucket_name=self.bucket_name,
+                    config=self.config,
+                    data_format_fn=self.data_format_fn,
+                    storage_client=client,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes  https://github.com/GoogleCloudPlatform/dataflux-pytorch/issues/58

The pickling error was due to passing storage client to pytorch dataloader. When num_workers>0, pytorch uses multi-processing. Multi-processing fails as it cannot serialize/pickle storage client and lambda function. 

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR