### PR TITLE
Disable compose download when create and delete permissions are missing

### DIFF
--- a/dataflux_pytorch/_helper.py
+++ b/dataflux_pytorch/_helper.py
@@ -1,0 +1,36 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
+
+import logging
+
+import dataflux_core
+from google.cloud import storage
+
+
+def _get_missing_permissions(storage_client: any, bucket_name: str,
+                             project_name: str, required_perm: any):
+    """Returns a list of missing permissions of the client from the required permissions list."""
+    if not storage_client:
+        storage_client = storage.Client(project=project_name)
+    dataflux_core.user_agent.add_dataflux_user_agent(storage_client)
+    bucket = storage_client.bucket(bucket_name)
+
+    try:
+        perm = bucket.test_iam_permissions(required_perm)
+    except Exception as e:
+        logging.exception(f"Error testing permissions: {e}")
+
+    return [p for p in required_perm if p not in perm]

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -126,8 +126,7 @@ class DataFluxIterableDataset(data.IterableDataset):
         if storage_client is not None and multiprocessing_start != FORK:
             warnings.warn(
                 "Setting the storage client is not fully supported when multiprocessing starts with spawn or forkserver methods.",
-                UserWarning,
-            )
+                UserWarning)
         self.storage_client = storage_client
         self.project_name = project_name
         self.bucket_name = bucket_name

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -19,6 +19,7 @@ import math
 import multiprocessing
 import os
 import warnings
+from dataflux_pytorch._helper import _get_missing_permissions
 
 import dataflux_core
 from google.api_core.client_info import ClientInfo
@@ -90,22 +91,6 @@ class Config:
 
 def data_format_default(data):
     return data
-
-
-def _get_missing_permissions(storage_client: any, bucket_name: str,
-                             project_name: str, required_perm: any):
-    """Returns a list of missing permissions of the client from the required permissions list."""
-    if not storage_client:
-        storage_client = storage.Client(project=project_name)
-    dataflux_core.user_agent.add_dataflux_user_agent(storage_client)
-    bucket = storage_client.bucket(bucket_name)
-
-    try:
-        perm = bucket.test_iam_permissions(required_perm)
-    except Exception as e:
-        logging.exception(f"Error testing permissions: {e}")
-
-    return [p for p in required_perm if p not in perm]
 
 
 class DataFluxIterableDataset(data.IterableDataset):

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -133,6 +133,9 @@ class DataFluxIterableDataset(data.IterableDataset):
         self.data_format_fn = data_format_fn
         self.config = config
         if not self._has_permissions():
+            logging.info(
+                f"Composed download was disabled as permissions to create or delete objects is missing."
+            )
             self.config.max_composite_object_size = 0
         self.dataflux_download_optimization_params = (
             dataflux_core.download.DataFluxDownloadOptimizationParams(

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -105,7 +105,7 @@ def _get_missing_permissions(storage_client: any, bucket_name: str,
     except Exception as e:
         logging.exception(f"Error testing permissions: {e}")
 
-    return [p for p in perm if p not in required_perm]
+    return [p for p in required_perm if p not in perm]
 
 
 class DataFluxIterableDataset(data.IterableDataset):
@@ -156,11 +156,10 @@ class DataFluxIterableDataset(data.IterableDataset):
                 bucket_name=self.bucket_name,
                 project_name=self.project_name,
                 required_perm=[CREATE, DELETE])
-            if len(missing_perm) > 0:
-                logging.warning(
-                    f"Composed download disabled as {missing_perm} permissions are missing."
+            if missing_perm and len(missing_perm) > 0:
+                raise PermissionError(
+                    f"Missing permissions {', '.join(missing_perm)} for composed download. To disable composed download set config.disable_compose=True. To enable composed download, grant missing permissions."
                 )
-                self.config.max_composite_object_size = 0
 
         self.dataflux_download_optimization_params = (
             dataflux_core.download.DataFluxDownloadOptimizationParams(

--- a/dataflux_pytorch/dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/dataflux_iterable_dataset.py
@@ -133,8 +133,8 @@ class DataFluxIterableDataset(data.IterableDataset):
         self.data_format_fn = data_format_fn
         self.config = config
         if not self._has_permissions():
-            logging.info(
-                f"Composed download was disabled as permissions to create or delete objects is missing."
+            logging.warning(
+                f"Composed download disabled as permissions to create or delete objects is missing."
             )
             self.config.max_composite_object_size = 0
         self.dataflux_download_optimization_params = (

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -145,11 +145,10 @@ class DataFluxMapStyleDataset(data.Dataset):
                 bucket_name=self.bucket_name,
                 project_name=self.project_name,
                 required_perm=[CREATE, DELETE])
-            if len(missing_perm) > 0:
-                logging.warning(
-                    f"Composed download disabled as {missing_perm} permissions are missing."
+            if missing_perm and len(missing_perm) > 0:
+                raise PermissionError(
+                    f"Missing permissions {', '.join(missing_perm)} for composed download. To disable composed download set config.disable_compose=True or to enable composed download, grant missing permissions."
                 )
-                self.config.max_composite_object_size = 0
 
         self.dataflux_download_optimization_params = (
             dataflux_core.download.DataFluxDownloadOptimizationParams(

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -26,8 +26,7 @@ from google.cloud.storage.retry import DEFAULT_RETRY
 from torch.utils import data
 
 MODIFIED_RETRY = DEFAULT_RETRY.with_deadline(100000.0).with_delay(
-    initial=1.0, multiplier=1.5, maximum=30.0
-)
+    initial=1.0, multiplier=1.5, maximum=30.0)
 
 FORK = "fork"
 CREATE = "storage.objects.create"
@@ -73,8 +72,10 @@ class Config:
         max_listing_retries: int = 3,
         threads_per_process: int = 1,
         disable_compose: bool = False,
-        list_retry_config: "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
-        download_retry_config: "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
+        list_retry_config:
+        "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
+        download_retry_config:
+        "google.api_core.retry.retry_unary.Retry" = MODIFIED_RETRY,
     ):
         self.sort_listing_results = sort_listing_results
         self.max_composite_object_size = max_composite_object_size
@@ -124,7 +125,8 @@ class DataFluxMapStyleDataset(data.Dataset):
             None.
         """
         super().__init__()
-        multiprocessing_start = multiprocessing.get_start_method(allow_none=False)
+        multiprocessing_start = multiprocessing.get_start_method(
+            allow_none=False)
         if storage_client is not None and multiprocessing_start != FORK:
             warnings.warn(
                 "Setting the storage client is not fully supported when multiprocessing starts with spawn or forkserver.",
@@ -140,8 +142,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.dataflux_download_optimization_params = (
             dataflux_core.download.DataFluxDownloadOptimizationParams(
                 max_composite_object_size=self.config.max_composite_object_size
-            )
-        )
+            ))
 
         self.objects = self._list_GCS_blobs_with_retry()
 
@@ -155,18 +156,18 @@ class DataFluxMapStyleDataset(data.Dataset):
                 bucket_name=self.bucket_name,
                 object_name=self.objects[idx][0],
                 retry_config=self.config.download_retry_config,
-            )
-        )
+            ))
 
     def __getitems__(self, indices):
         return [
-            self.data_format_fn(bytes_content)
-            for bytes_content in dataflux_core.download.dataflux_download_threaded(
+            self.data_format_fn(bytes_content) for bytes_content in
+            dataflux_core.download.dataflux_download_threaded(
                 project_name=self.project_name,
                 bucket_name=self.bucket_name,
                 objects=[self.objects[idx] for idx in indices],
                 storage_client=self.storage_client,
-                dataflux_download_optimization_params=self.dataflux_download_optimization_params,
+                dataflux_download_optimization_params=self.
+                dataflux_download_optimization_params,
                 threads=self.config.threads_per_process,
                 retry_config=self.config.download_retry_config,
             )
@@ -209,9 +210,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         """Check if the client has permission to create and delete an object."""
         storage_client = self.storage_client
         if not storage_client:
-            storage_client = storage.Client(
-                project=self.project_name,
-            )
+            storage_client = storage.Client(project=self.project_name, )
         dataflux_core.user_agent.add_dataflux_user_agent(storage_client)
 
         required_permission = [CREATE, DELETE]

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -138,8 +138,8 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.data_format_fn = data_format_fn
         self.config = config
         if not self._has_permissions():
-            logging.info(
-                f"Composed download was disabled as permissions to create or delete objects is missing."
+            logging.warning(
+                f"Composed download disabled as permissions to create or delete objects is missing."
             )
             self.config.max_composite_object_size = 0
         self.dataflux_download_optimization_params = (

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -138,6 +138,9 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.data_format_fn = data_format_fn
         self.config = config
         if not self._has_permissions():
+            logging.info(
+                f"Composed download was disabled as permissions to create or delete objects is missing."
+            )
             self.config.max_composite_object_size = 0
         self.dataflux_download_optimization_params = (
             dataflux_core.download.DataFluxDownloadOptimizationParams(

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -20,7 +20,7 @@ import os
 import warnings
 
 import dataflux_core
-from dataflux_pytorch import dataflux_iterable_dataset
+from dataflux_pytorch._helper import _get_missing_permissions
 from google.api_core.client_info import ClientInfo
 from google.cloud import storage
 from google.cloud.storage.retry import DEFAULT_RETRY
@@ -140,7 +140,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.config = config
         # If composed download is enabled, check if the client has permissions to create and delete the composed object.
         if self.config.max_composite_object_size != 0:
-            missing_perm = dataflux_iterable_dataset._get_missing_permissions(
+            missing_perm = _get_missing_permissions(
                 storage_client=self.storage_client,
                 bucket_name=self.bucket_name,
                 project_name=self.project_name,

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -41,8 +41,15 @@ class IterableDatasetTestCase(unittest.TestCase):
         client = fake_gcs.Client()
 
         self.want_objects = [("objectA", 1), ("objectB", 2)]
-        for (name, length) in self.want_objects:
-            client.bucket(self.bucket_name)._add_file(name, length * '0')
+        for name, length in self.want_objects:
+            client.bucket(self.bucket_name)._add_file(name, length * "0")
+        client._set_perm(
+            [
+                dataflux_iterable_dataset.CREATE,
+                dataflux_iterable_dataset.DELETE
+            ],
+            self.bucket_name,
+        )
         self.storage_client = client
 
     @mock.patch("dataflux_pytorch.dataflux_iterable_dataset.dataflux_core")
@@ -316,7 +323,8 @@ class IterableDatasetTestCase(unittest.TestCase):
         """Tests the DataFluxIterableDataset returns pickling error for passing-in client when multiprcessing start method is spawn."""
         # Act.
         client = storage.Client(project=self.project_name)
-        if multiprocessing.get_start_method(allow_none=False) != "fork":
+        if (multiprocessing.get_start_method(allow_none=False)
+                != dataflux_iterable_dataset.FORK):
             with self.assertRaises(pickle.PicklingError):
                 dataflux_iterable_dataset.DataFluxIterableDataset(
                     project_name=self.project_name,
@@ -325,6 +333,56 @@ class IterableDatasetTestCase(unittest.TestCase):
                     data_format_fn=self.data_format_fn,
                     storage_client=client,
                 )
+
+    def test_init_sets_perm_false(self):
+        """Tests that the compose download is disabled when create and delete permissions are missing."""
+
+        # Arrange.
+        self.storage_client._set_perm([], self.bucket_name)
+
+        # Act.
+        ds = dataflux_iterable_dataset.DataFluxIterableDataset(
+            project_name=self.project_name,
+            bucket_name=self.bucket_name,
+            config=self.config,
+            data_format_fn=self.data_format_fn,
+            storage_client=self.storage_client,
+        )
+
+        # Since required permission is missing, max_composite_object_size is 0.
+        self.assertEqual(
+            ds.config.max_composite_object_size,
+            0,
+            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {0}",
+        )
+
+    def test_init_sets_perm_true(self):
+        """Tests that the compose download is not disabled when create and delete permissions exists."""
+        # Arrange.
+        self.storage_client._set_perm(
+            [
+                dataflux_iterable_dataset.CREATE,
+                dataflux_iterable_dataset.DELETE
+            ],
+            self.bucket_name,
+        )
+        want_size = self.config.max_composite_object_size
+
+        # Act.
+        ds = dataflux_iterable_dataset.DataFluxIterableDataset(
+            project_name=self.project_name,
+            bucket_name=self.bucket_name,
+            config=self.config,
+            data_format_fn=self.data_format_fn,
+            storage_client=self.storage_client,
+        )
+
+        # Since required permission exists, max_composite_object_size will not change.
+        self.assertEqual(
+            ds.config.max_composite_object_size,
+            want_size,
+            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {0}",
+        )
 
 
 if __name__ == "__main__":

--- a/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_iterable_dataset.py
@@ -353,7 +353,7 @@ class IterableDatasetTestCase(unittest.TestCase):
         self.assertEqual(
             ds.config.max_composite_object_size,
             0,
-            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {0}",
+            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want 0",
         )
 
     def test_init_sets_perm_true(self):
@@ -381,7 +381,7 @@ class IterableDatasetTestCase(unittest.TestCase):
         self.assertEqual(
             ds.config.max_composite_object_size,
             want_size,
-            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {0}",
+            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {want_size}",
         )
 
 

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -295,49 +295,38 @@ class ListingTestCase(unittest.TestCase):
         """Tests the DataFluxIterableDataset returns pickling error for passing-in client when multiprcessing start method is spawn."""
         # Act.
         client = storage.Client(project=self.project_name)
+        config = self.config
+        config.max_composite_object_size = 0
         if (multiprocessing.get_start_method(allow_none=False)
                 != dataflux_mapstyle_dataset.FORK):
             with self.assertRaises(pickle.PicklingError):
                 dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
                     project_name=self.project_name,
                     bucket_name=self.bucket_name,
-                    config=self.config,
+                    config=config,
                     data_format_fn=self.data_format_fn,
                     storage_client=client,
                 )
 
-    def test_init_sets_perm_false(self):
-        """Tests that the compose download is disabled when create and delete permissions are missing."""
-
+    def test_init_without_perm(self):
+        """Tests that the DataFluxIterableDataset returns permission error when create and delete permissions are missing."""
         # Arrange.
-        self.storage_client._set_perm([], self.bucket_name)
-
-        # Act.
-        ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
-            project_name=self.project_name,
-            bucket_name=self.bucket_name,
-            config=self.config,
-            data_format_fn=self.data_format_fn,
-            storage_client=self.storage_client,
-        )
+        client = self.storage_client
+        client._set_perm([], self.bucket_name)
 
         # Since required permission is missing, max_composite_object_size is 0.
-        self.assertEqual(
-            ds.config.max_composite_object_size,
-            0,
-            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want 0",
-        )
+        with self.assertRaises(PermissionError):
+            ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
+                project_name=self.project_name,
+                bucket_name=self.bucket_name,
+                config=self.config,
+                data_format_fn=self.data_format_fn,
+                storage_client=client,
+            )
 
-    def test_init_sets_perm_true(self):
+    def test_init_with_perm(self):
         """Tests that the compose download is not disabled when create and delete permissions exists."""
         # Arrange.
-        self.storage_client._set_perm(
-            [
-                dataflux_mapstyle_dataset.CREATE,
-                dataflux_mapstyle_dataset.DELETE
-            ],
-            self.bucket_name,
-        )
         want_size = self.config.max_composite_object_size
 
         # Act.

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -39,16 +39,12 @@ class ListingTestCase(unittest.TestCase):
         client = fake_gcs.Client()
 
         self.want_objects = [("objectA", 1), ("objectB", 2)]
-        for name, length in self.want_objects:
+        for (name, length) in self.want_objects:
             client.bucket(self.bucket_name)._add_file(
                 self.config.prefix + name, length * "0")
-        client._set_perm(
-            [
-                dataflux_mapstyle_dataset.CREATE,
-                dataflux_mapstyle_dataset.DELETE
-            ],
-            self.bucket_name,
-        )
+        client._set_perm([
+            dataflux_mapstyle_dataset.CREATE, dataflux_mapstyle_dataset.DELETE
+        ], self.bucket_name)
         self.storage_client = client
 
     @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -325,7 +325,7 @@ class ListingTestCase(unittest.TestCase):
         self.assertEqual(
             ds.config.max_composite_object_size,
             0,
-            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {0}",
+            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want 0",
         )
 
     def test_init_sets_perm_true(self):
@@ -353,7 +353,7 @@ class ListingTestCase(unittest.TestCase):
         self.assertEqual(
             ds.config.max_composite_object_size,
             want_size,
-            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {0}",
+            f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {want_size}",
         )
 
 


### PR DESCRIPTION
Dataflux pytorch dataset fail when user does not have required permissions to create and delete composed objects.
If user doesn't have required permissions, set max_composite_size to 0.

Related Issue: https://github.com/GoogleCloudPlatform/dataflux-pytorch/issues/58#issuecomment-2231552178

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR