### PR TITLE
Install pytest on running continuous  test for dataflux pypi package.

### DIFF
--- a/kokoro/pypi.sh
+++ b/kokoro/pypi.sh
@@ -44,6 +44,9 @@ function install_requirements() {
     echo Installing python3-pip.
     sudo apt-get -y install python3-pip
 
+    echo Installing pytest.
+    pip install pytest
+
     echo Installing project from PyPI.
     pip install gcs-torch-dataflux
 }


### PR DESCRIPTION
Continuous test for dataflux PyPI package failed with `pyenv: pytest: command not found`

Reproduced the error and resolved by installing pytest. 
Sponge Link: http://sponge2.corp.google.com/e4828e42-9737-4243-aa62-f4a87c161ad9

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR