### PR TITLE
Initialize new storage_client.bucket on every request

### DIFF
--- a/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, Tuple
 
 import torch
 from dataflux_core import user_agent
@@ -17,7 +17,6 @@ class DatafluxLightningCheckpoint(CheckpointIO):
     ):
         self.project_name = project_name
         self.storage_client = storage_client
-        self.bucket = None
         if not storage_client:
             self.storage_client = storage.Client(project=self.project_name, )
         user_agent.add_dataflux_user_agent(self.storage_client)
@@ -33,7 +32,7 @@ class DatafluxLightningCheckpoint(CheckpointIO):
             raise TypeError(
                 "path argument must be of type string or pathlib.Path object")
 
-    def _parse_gcs_path(self, path: Union[str, Path]) -> str:
+    def _parse_gcs_path(self, path: Union[str, Path]) -> Tuple[str, str]:
         if not path:
             raise ValueError("Path cannot be empty")
         input_path = self._process_input_path(path)
@@ -52,8 +51,7 @@ class DatafluxLightningCheckpoint(CheckpointIO):
             bucket_name, prefix = split
         if not bucket_name:
             raise ValueError("Bucket name must be non-empty")
-        self.bucket = self.storage_client.bucket(bucket_name)
-        return prefix
+        return prefix, bucket_name
 
     def save_checkpoint(
         self,
@@ -61,8 +59,9 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         path: Union[str, Path],
         storage_options: Optional[Any] = None,
     ) -> None:
-        key = self._parse_gcs_path(path)
-        blob = self.bucket.blob(key)
+        key, bucket_name = self._parse_gcs_path(path)
+        bucket_client = self.storage_client.bucket(bucket_name)
+        blob = bucket_client.blob(key)
         with blob.open("wb", ignore_flush=True) as blobwriter:
             torch.save(checkpoint, blobwriter)
 
@@ -71,16 +70,18 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         path: Union[str, Path],
         map_location: Optional[Any] = None,
     ) -> Dict[str, Any]:
-        key = self._parse_gcs_path(path)
-        blob = self.bucket.blob(key)
+        key, bucket_name = self._parse_gcs_path(path)
+        bucket_client = self.storage_client.bucket(bucket_name)
+        blob = bucket_client.blob(key)
         return torch.load(blob.open("rb"), map_location)
 
     def remove_checkpoint(
         self,
         path: Union[str, Path],
     ) -> None:
-        key = self._parse_gcs_path(path)
-        blob = self.bucket.blob(key)
+        key, bucket_name = self._parse_gcs_path(path)
+        bucket_client = self.storage_client.bucket(bucket_name)
+        blob = bucket_client.blob(key)
         blob.delete()
 
     def teardown(self, ) -> None:

--- a/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
@@ -52,8 +52,7 @@ class DatafluxLightningCheckpoint(CheckpointIO):
             bucket_name, prefix = split
         if not bucket_name:
             raise ValueError("Bucket name must be non-empty")
-        if not self.bucket:
-            self.bucket = self.storage_client.bucket(bucket_name)
+        self.bucket = self.storage_client.bucket(bucket_name)
         return prefix
 
     def save_checkpoint(

--- a/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
@@ -51,7 +51,7 @@ class DatafluxLightningCheckpoint(CheckpointIO):
             bucket_name, prefix = split
         if not bucket_name:
             raise ValueError("Bucket name must be non-empty")
-        return prefix, bucket_name
+        return bucket_name, prefix
 
     def save_checkpoint(
         self,
@@ -59,7 +59,7 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         path: Union[str, Path],
         storage_options: Optional[Any] = None,
     ) -> None:
-        key, bucket_name = self._parse_gcs_path(path)
+        bucket_name, key = self._parse_gcs_path(path)
         bucket_client = self.storage_client.bucket(bucket_name)
         blob = bucket_client.blob(key)
         with blob.open("wb", ignore_flush=True) as blobwriter:
@@ -70,7 +70,7 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         path: Union[str, Path],
         map_location: Optional[Any] = None,
     ) -> Dict[str, Any]:
-        key, bucket_name = self._parse_gcs_path(path)
+        bucket_name, key = self._parse_gcs_path(path)
         bucket_client = self.storage_client.bucket(bucket_name)
         blob = bucket_client.blob(key)
         return torch.load(blob.open("rb"), map_location)
@@ -79,7 +79,7 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         self,
         path: Union[str, Path],
     ) -> None:
-        key, bucket_name = self._parse_gcs_path(path)
+        bucket_name, key = self._parse_gcs_path(path)
         bucket_client = self.storage_client.bucket(bucket_name)
         blob = bucket_client.blob(key)
         blob.delete()


### PR DESCRIPTION
Remove the check to initialize bucket client only once, since we want to be able to pass different GCS buckets in save/restore/delete checkpointing functions.

This is in regards to comment on https://github.com/GoogleCloudPlatform/dataflux-pytorch/pull/85


- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR