### PR TITLE
Allow running demo code in listing-only mode

### DIFF
--- a/demo/lightning/image-segmentation/README.md
+++ b/demo/lightning/image-segmentation/README.md
@@ -3,7 +3,7 @@ The code examples in this directory demonstrate how GCS Connector for Pytorch ca
 
 If you are looking to benchmark data loading performance, pass `--benchmark` to `train.py`. Note that this will run the training loop but does not run the actual training logic.
 
-If you are looking to benchmark just the listing performance, pass `--listing_only` to `train.py`. Note that this will skip training altogether.
+If you are looking to benchmark the listing performance only, pass `--listing_only` to `train.py`. Note that this will skip training altogether. Passing `--benchmark` along with `--listing_only` would have the same effect as passing just the latter.
 
 
 1. `dataset.py`

--- a/demo/lightning/image-segmentation/README.md
+++ b/demo/lightning/image-segmentation/README.md
@@ -1,7 +1,10 @@
 # Image Segmentation Demo Code
 The code examples in this directory demonstrate how GCS Connector for Pytorch can be used for image segmentation training alongside PyTorch Lightning. The image segmentation workload implemented here works on the [KiTS19](https://github.com/neheller/kits19) dataset which contains `210` images and their corresponding labels. The images and their labels are stored in separate directories.
 
-If you are looking to benchmark data loading performance, pass `--benchmark` to `train.py`. Note that this will skip training altogether.
+If you are looking to benchmark data loading performance, pass `--benchmark` to `train.py`. Note that this will run the training loop but does not run the actual training logic.
+
+If you are looking to benchmark just the listing performance, pass `--listing_only` to `train.py`. Note that this will skip training altogether.
+
 
 1. `dataset.py`
 

--- a/demo/lightning/image-segmentation/arguments.py
+++ b/demo/lightning/image-segmentation/arguments.py
@@ -77,6 +77,10 @@ PARSER.add_argument("--benchmark",
                     dest="benchmark",
                     default=False,
                     action="store_true")
+PARSER.add_argument("--listing_only",
+                    dest="listing_only",
+                    default=False,
+                    action="store_true")
 PARSER.add_argument("--amp", dest="amp", action="store_true", default=False)
 PARSER.add_argument(
     "--optimizer",

--- a/demo/lightning/image-segmentation/train.py
+++ b/demo/lightning/image-segmentation/train.py
@@ -57,16 +57,16 @@ if __name__ == "__main__":
     if flags.listing_only:
         print(
             f"Skipping training because you've set listing_only to True.")
-        exit(0)
+    else:
+        model = Unet3DLightning(flags)
+        trainer = pl.Trainer(
+            accelerator=flags.accelerator,
+            max_epochs=flags.epochs,
+            devices=flags.num_devices,
+            num_nodes=flags.num_nodes,
+            strategy="ddp",
+            profiler=profiler,
+        )
+        trainer.fit(model=model, train_dataloaders=train_data_loader)
 
-    model = Unet3DLightning(flags)
-    trainer = pl.Trainer(
-        accelerator=flags.accelerator,
-        max_epochs=flags.epochs,
-        devices=flags.num_devices,
-        num_nodes=flags.num_nodes,
-        strategy="ddp",
-        profiler=profiler,
-    )
-    trainer.fit(model=model, train_dataloaders=train_data_loader)
     print(f"Listing took {listing_end - listing_start} seconds.")

--- a/demo/lightning/image-segmentation/train.py
+++ b/demo/lightning/image-segmentation/train.py
@@ -56,7 +56,7 @@ if __name__ == "__main__":
     listing_end = time.time()
     if flags.listing_only:
         print(
-            f"Skipping training because you've set listing_only to True\nListing took {listing_end - listing_start} seconds.")
+            f"Skipping training because you've set listing_only to True.")
         exit(0)
 
     model = Unet3DLightning(flags)
@@ -69,3 +69,4 @@ if __name__ == "__main__":
         profiler=profiler,
     )
     trainer.fit(model=model, train_dataloaders=train_data_loader)
+    print(f"Listing took {listing_end - listing_start} seconds.")

--- a/demo/lightning/image-segmentation/train.py
+++ b/demo/lightning/image-segmentation/train.py
@@ -51,8 +51,15 @@ if __name__ == "__main__":
     if flags.benchmark:
         profiler = "simple"
 
-    model = Unet3DLightning(flags)
+    listing_start = time.time()
     train_data_loader = Unet3DDataModule(flags)
+    listing_end = time.time()
+    if flags.listing_only:
+        print(
+            f"Skipping training because you've set listing_only to True\nListing took {listing_end - listing_start} seconds.")
+        exit(0)
+
+    model = Unet3DLightning(flags)
     trainer = pl.Trainer(
         accelerator=flags.accelerator,
         max_epochs=flags.epochs,


### PR DESCRIPTION
Training in skipped when `--listing_only` is passed to `train.py` and exits right after initializing the map style datasets.


- [X] Tests pass; ran locally and verified listing time is output when this flag is set
- [X] Appropriate changes to documentation are included in the PR