### PR TITLE
Update defaults for batch_size and num_workers

### DIFF
--- a/demo/lightning/image-segmentation/arguments.py
+++ b/demo/lightning/image-segmentation/arguments.py
@@ -48,7 +48,7 @@ PARSER.add_argument("--quality_threshold",
                     default=0.908)
 PARSER.add_argument("--ga_steps", dest="ga_steps", type=int, default=1)
 PARSER.add_argument("--warmup_steps", dest="warmup_steps", type=int, default=4)
-PARSER.add_argument("--batch_size", dest="batch_size", type=int, default=50)
+PARSER.add_argument("--batch_size", dest="batch_size", type=int, default=20)
 PARSER.add_argument("--layout",
                     dest="layout",
                     type=str,
@@ -67,7 +67,9 @@ PARSER.add_argument("--num_devices", dest="num_devices", type=int, default=1)
 PARSER.add_argument("--num_nodes", dest="num_nodes", type=int, default=1)
 PARSER.add_argument("--num_workers", dest="num_workers", type=int, default=2)
 PARSER.add_argument("--prefetch_factor",
-                    dest="prefetch_factor", type=int, default=2)
+                    dest="prefetch_factor",
+                    type=int,
+                    default=2)
 PARSER.add_argument("--exec_mode",
                     dest="exec_mode",
                     choices=["train", "evaluate"],

--- a/demo/lightning/image-segmentation/arguments.py
+++ b/demo/lightning/image-segmentation/arguments.py
@@ -65,7 +65,7 @@ PARSER.add_argument("--val_input_shape",
 PARSER.add_argument("--seed", dest="seed", default=-1, type=int)
 PARSER.add_argument("--num_devices", dest="num_devices", type=int, default=1)
 PARSER.add_argument("--num_nodes", dest="num_nodes", type=int, default=1)
-PARSER.add_argument("--num_workers", dest="num_workers", type=int, default=2)
+PARSER.add_argument("--num_workers", dest="num_workers", type=int, default=10)
 PARSER.add_argument("--prefetch_factor",
                     dest="prefetch_factor",
                     type=int,

--- a/demo/lightning/image-segmentation/deploy.yaml
+++ b/demo/lightning/image-segmentation/deploy.yaml
@@ -81,7 +81,7 @@ spec:
                 - bash
                 - -c
                 - |
-                  python3 -u /app/demo/lightning/image-segmentation/train.py --gcp_project=<YOUR-GCP-PROJECT> --images_prefix=<YOUR-IMAGES-PREFIX> --labels_prefix=<YOUR-LABELS-PREFIX> --gcs_bucket=<YOUR-GCS-BUCKET> --batch_size= 20 --num_workers=10 --prefetch_factor=10 --num_devices=1 --num_nodes=4;
+                  python3 -u /app/demo/lightning/image-segmentation/train.py --gcs_bucket=<YOUR-GCS-BUCKET> --gcp_project=<YOUR-GCP-PROJECT> --images_prefix=<YOUR-IMAGES-PREFIX> --labels_prefix=<YOUR-LABELS-PREFIX> --batch_size=20 --num_workers=10 --prefetch_factor=2 --num_devices=1 --num_nodes=4;
               volumes:
                 - emptyDir:
                     medium: Memory

--- a/demo/lightning/image-segmentation/deploy.yaml
+++ b/demo/lightning/image-segmentation/deploy.yaml
@@ -81,7 +81,7 @@ spec:
                 - bash
                 - -c
                 - |
-                  python3 -u /app/demo/lightning/image-segmentation/train.py --gcp_project=<YOUR-GCP-PROJECT> --images_prefix=<YOUR-IMAGES-PREFIX> --labels_prefix=<YOUR-LABELS-PREFIX> --gcs_bucket=<YOUR-GCS-BUCKET> --num_workers=10 --prefetch_factor=10 --num_devices=1 --num_nodes=4;
+                  python3 -u /app/demo/lightning/image-segmentation/train.py --gcp_project=<YOUR-GCP-PROJECT> --images_prefix=<YOUR-IMAGES-PREFIX> --labels_prefix=<YOUR-LABELS-PREFIX> --gcs_bucket=<YOUR-GCS-BUCKET> --batch_size= 20 --num_workers=10 --prefetch_factor=10 --num_devices=1 --num_nodes=4;
               volumes:
                 - emptyDir:
                     medium: Memory

--- a/demo/lightning/image-segmentation/model.py
+++ b/demo/lightning/image-segmentation/model.py
@@ -56,7 +56,7 @@ class Unet3DLightning(pl.LightningModule):
     def training_step(self, train_batch, batch_idx):
         images, labels = train_batch
         if self.benchmark:
-            return None
+            return torch.tensor(1, dtype=float, requires_grad=True)
         predictions = self.model(images)
         loss = self.loss_fn(predictions, labels)
         return loss

--- a/demo/lightning/image-segmentation/model.py
+++ b/demo/lightning/image-segmentation/model.py
@@ -56,7 +56,8 @@ class Unet3DLightning(pl.LightningModule):
     def training_step(self, train_batch, batch_idx):
         images, labels = train_batch
         if self.benchmark:
-            # Return a scalar of value 1 to speed up training_step.
+            # Returning None will break distributed training, so
+            # return a scalar of value 1 to speed up training_step.
             return torch.tensor(1, dtype=float, requires_grad=True)
         predictions = self.model(images)
         loss = self.loss_fn(predictions, labels)

--- a/demo/lightning/image-segmentation/model.py
+++ b/demo/lightning/image-segmentation/model.py
@@ -57,7 +57,7 @@ class Unet3DLightning(pl.LightningModule):
         images, labels = train_batch
         if self.benchmark:
             # Returning None will break distributed training, so
-            # return a scalar of value 1 to speed up training_step.
+            # return a scalar of value 1 that represents loss to skip training.
             return torch.tensor(1, dtype=float, requires_grad=True)
         predictions = self.model(images)
         loss = self.loss_fn(predictions, labels)

--- a/demo/lightning/image-segmentation/model.py
+++ b/demo/lightning/image-segmentation/model.py
@@ -56,6 +56,7 @@ class Unet3DLightning(pl.LightningModule):
     def training_step(self, train_batch, batch_idx):
         images, labels = train_batch
         if self.benchmark:
+            # Return a scalar of value 1 to speed up training_step.
             return torch.tensor(1, dtype=float, requires_grad=True)
         predictions = self.model(images)
         loss = self.loss_fn(predictions, labels)


### PR DESCRIPTION
Update command in deployment file with batch_size and num_workers set to values that gave us best egress BW for 150MB dataset

Also, `Unet3DLightning.training_step` now returns a scalar (that represents loss) instead of None to skip actual training. This is because pytorch lightning does not allow skipping training when run on multiple nodes (returning None on single node training works just fine!)

- [X] Tests pass; deployed on a 10 node cluster and verified that the workload finished successfully
- [X] Appropriate changes to documentation are included in the PR - N/A