### PR TITLE
Use Transfer Manager for reading and writing PyTorch Lightning checkpoints

### DIFF
--- a/dataflux_pytorch/benchmark/README.md
+++ b/dataflux_pytorch/benchmark/README.md
@@ -83,7 +83,7 @@ Average time to load one checkpoint: 63.66342296364783 seconds
 The table below contains benchmarking times on saving checkpoints to GCS. For 10/100-layer checkpoints the average save/load times is taken over 20 calls to save_checkpoint or load_checkpoint, and 10 calls for 1000 layers. The tests were done from a VM with 48vCPU, 192 GB RAM, 512 GB SSD located in `us-west1-a` zone. The GCS bucket was located in the same region, `us-west1`.
 
 
-Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing active development. The numbers below will be continuously updated to reflect the current state and performance of Dataflux's PyTorch Lightning checkpoint utility. These values are compared to `TorchCheckpointIO`, which refers to PyTorch Lightning's default [TorchCheckpointIO](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.plugins.io.TorchCheckpointIO.html) implementation. A value is provided for local writes to a local SSD on GCE, as well as for direct writes to GCS using gcsfs via the default implementation.
+Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing active development. The numbers below will be continuously updated to reflect the current state and performance of Dataflux's PyTorch Lightning checkpoint utility. These values are compared to `TorchCheckpointIO`, which refers to PyTorch Lightning's default [TorchCheckpointIO](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.plugins.io.TorchCheckpointIO.html) implementation. A value is provided for direct writes and reads with GCS using gcsfs via the default implementation.
 
 ### Saving Checkpoints
 
@@ -98,18 +98,6 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    <td style="background-color: #d9d2e9"><strong>Average Checkpoint Save Time</strong>
    </td>
    <td style="background-color: #d9d2e9"><strong>Write Throughput (MB/s)</strong>
-   </td>
-  </tr>
-  <tr>
-   <td style="background-color: #f3f3f3">TorchCheckpointIO (Local SSD)
-   </td>
-   <td style="background-color: #f3f3f3">10
-   </td>
-   <td style="background-color: #f3f3f3">75.6
-   </td>
-   <td style="background-color: #f3f3f3">0.42
-   </td>
-   <td style="background-color: #f3f3f3">180.0
    </td>
   </tr>
   <tr>
@@ -149,18 +137,6 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9">TorchCheckpointIO (Local SSD)
-   </td>
-   <td style="background-color: #d9d9d9">100
-   </td>
-   <td style="background-color: #d9d9d9">298
-   </td>
-   <td style="background-color: #d9d9d9">2.02
-   </td>
-   <td style="background-color: #d9d9d9">147.5
-   </td>
-  </tr>
-  <tr>
    <td style="background-color: #d9d9d9">TorchCheckpointIO (gcsfs)
    </td>
    <td style="background-color: #d9d9d9">100
@@ -194,18 +170,6 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    <td style="background-color: #d9d9d9">1.19
    </td>
    <td style="background-color: #d9d9d9">250.4
-   </td>
-  </tr>
-  <tr>
-   <td style="background-color: #f3f3f3">TorchCheckpointIO (Local SSD)
-   </td>
-   <td style="background-color: #f3f3f3">1000
-   </td>
-   <td style="background-color: #f3f3f3">2500
-   </td>
-   <td style="background-color: #f3f3f3">24.05
-   </td>
-   <td style="background-color: #f3f3f3">104.0
    </td>
   </tr>
   <tr>
@@ -262,18 +226,6 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    </td>
   </tr>
   <tr>
-   <td style="background-color: #f3f3f3">TorchCheckpointIO (Local SSD)
-   </td>
-   <td style="background-color: #f3f3f3">10
-   </td>
-   <td style="background-color: #f3f3f3">75.6
-   </td>
-   <td style="background-color: #f3f3f3">0.03
-   </td>
-   <td style="background-color: #f3f3f3">2520.0
-   </td>
-  </tr>
-  <tr>
    <td style="background-color: #f3f3f3">TorchCheckpointIO (gcsfs)
    </td>
    <td style="background-color: #f3f3f3">10
@@ -310,18 +262,6 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9">TorchCheckpointIO (Local SSD)
-   </td>
-   <td style="background-color: #d9d9d9">100
-   </td>
-   <td style="background-color: #d9d9d9">298
-   </td>
-   <td style="background-color: #d9d9d9">0.18
-   </td>
-   <td style="background-color: #d9d9d9">1655.6
-   </td>
-  </tr>
-  <tr>
    <td style="background-color: #d9d9d9">TorchCheckpointIO (gcsfs)
    </td>
    <td style="background-color: #d9d9d9">100
@@ -355,18 +295,6 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    <td style="background-color: #d9d9d9">1.72
    </td>
    <td style="background-color: #d9d9d9">173.3
-   </td>
-  </tr>
-  <tr>
-   <td style="background-color: #f3f3f3">TorchCheckpointIO (Local SSD)
-   </td>
-   <td style="background-color: #f3f3f3">1000
-   </td>
-   <td style="background-color: #f3f3f3">2500
-   </td>
-   <td style="background-color: #f3f3f3">2.14
-   </td>
-   <td style="background-color: #f3f3f3">1168.2
    </td>
   </tr>
   <tr>

--- a/dataflux_pytorch/benchmark/README.md
+++ b/dataflux_pytorch/benchmark/README.md
@@ -1,13 +1,14 @@
 # Benchmarking PyTorch Lightning Checkpoints with Google Cloud Storage
 
-This benchmarking script will allow you to run and benchmark the performance of the PyTorch Lightning Checkpoint save function. This script does not rely on GPUs, TPUs or CPU Clusters and can be run directly on your machine. The script runs the `WikiText2` PyTorch Lightning demo code with some modifications.
+This benchmarking script will allow you to run and benchmark the performance of the PyTorch Lightning Checkpoint save/load function. This script does not rely on GPUs, TPUs or CPU Clusters and can be run directly on your machine. The script runs the `WikiText2` PyTorch Lightning demo code with some modifications.
 
 ## Getting started
 
 ### Installation
 
 ```shell
-pip install gcs-torch-dataflux gcsfs
+pip install gcsfs
+pip install .
 ```
 
 ### Configuration
@@ -20,7 +21,7 @@ gcloud config set project {PROJECT_ID}
 
 Then set the enviroment variables.
 
-`CKPT_DIR_PATH` is the location of where to save the checkpoints. `STEPS` is the number of steps the model will take (the number of checkpoints created will be the same). The default value for `STEPS` is 5. The benchmark will run `save_checkpoint` repeatedly and produce the average at the end.
+`CKPT_DIR_PATH` is the location of where to save the checkpoints. `STEPS` is the number of steps the model will take (the number of checkpoints created will be the same). The default value for `STEPS` is 5. The benchmark will run `save_checkpoint` and `load_checkpoint` repeatedly and produce the average at the end for each. 
 
 ```shell
 export CKPT_DIR_PATH=`gs://path/to/directory/`
@@ -37,9 +38,12 @@ export LAYERS=1000
 
 If you are benchmarking Dataflux Lightning Checkpoint, save information regarding your project and make sure to enable the flag by setting it to `1`.
 
+You can also control whether Transfer Manager is used to do multipart-upload and multipart-download of the checkpoints by setting the `USE_TRANSFER_MANAGER` flag. Note that the default is true for the checkpointer, but will only be used here if you set it:
+
 ```shell
 export PROJECT=`YOUR_PROJECT_NAME`
 export DATAFLUX_CKPT=1
+export USE_TRANSFER_MANAGER=1
 ```
 
 ### Running
@@ -71,14 +75,17 @@ HPU available: False, using: 0 HPUs
 Epoch 0:   0%|                                                                                                            | 10/59674 [12:17<1221:29:06,  0.01it/s, v_num=5]`Trainer.fit` stopped: `max_steps=10` reached.
 Epoch 0:   0%|                                                                                                            | 10/59674 [12:17<1221:29:09,  0.01it/s, v_num=5]
 Average time to save one checkpoint: 58.68560411930084 seconds
+Average time to load one checkpoint: 63.66342296364783 seconds
 ```
 
 ## Results
 
-The table below contains benchmarking times on saving checkpoints to GCS, the average save time is taken over 10 calls to save_checkpoint. The tests were done from a VM with 48vCPU, 192 GB RAM, 512 GB SSD located in `us-west1-a` zone. The GCS bucket was located in the same region, `us-west1`.
+The table below contains benchmarking times on saving checkpoints to GCS. For 10/100-layer checkpoints the average save/load times is taken over 20 calls to save_checkpoint or load_checkpoint, and 10 calls for 1000 layers. The tests were done from a VM with 48vCPU, 192 GB RAM, 512 GB SSD located in `us-west1-a` zone. The GCS bucket was located in the same region, `us-west1`.
 
 
-Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing active development. The numbers below will be continuously updated to reflect the current state and performance of Dataflux's PyTorch Lightning checkpoint utility. These values are compared to `Default`, which refers to fsspec.
+Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing active development. The numbers below will be continuously updated to reflect the current state and performance of Dataflux's PyTorch Lightning checkpoint utility. These values are compared to `TorchCheckpointIO`, which refers to PyTorch Lightning's default [TorchCheckpointIO](https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.plugins.io.TorchCheckpointIO.html) implementation. A value is provided for local writes to a local SSD on GCE, as well as for direct writes to GCS using gcsfs via the default implementation.
+
+### Saving Checkpoints
 
 <table>
   <tr>
@@ -94,75 +101,308 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9"> Default
-   </td>
-   <td style="background-color: #d9d9d9">10
-   </td>
-   <td style="background-color: #d9d9d9">75.6
-   </td>
-   <td style="background-color: #d9d9d9">0.81
-   </td>
-   <td style="background-color: #d9d9d9">93.33
-   </td>
-  </tr>
-  <tr>
-   <td style="background-color: #f3f3f3">Dataflux
+   <td style="background-color: #f3f3f3">TorchCheckpointIO (Local SSD)
    </td>
    <td style="background-color: #f3f3f3">10
    </td>
    <td style="background-color: #f3f3f3">75.6
    </td>
-   <td style="background-color: #f3f3f3">0.74
+   <td style="background-color: #f3f3f3">0.42
    </td>
-   <td style="background-color: #f3f3f3">102.16
+   <td style="background-color: #f3f3f3">180.0
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9">Default
+   <td style="background-color: #f3f3f3">TorchCheckpointIO (gcsfs)
+   </td>
+   <td style="background-color: #f3f3f3">10
+   </td>
+   <td style="background-color: #f3f3f3">75.6
+   </td>
+   <td style="background-color: #f3f3f3">0.89
+   </td>
+   <td style="background-color: #f3f3f3">84.9
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux (Transfer Manager Disabled)
+   </td>
+   <td style="background-color: #f3f3f3">10
+   </td>
+   <td style="background-color: #f3f3f3">75.6
+   </td>
+   <td style="background-color: #f3f3f3">0.80
+   </td>
+   <td style="background-color: #f3f3f3">94.5
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux (Transfer Manager Enabled)
+   </td>
+   <td style="background-color: #f3f3f3">10
+   </td>
+   <td style="background-color: #f3f3f3">75.6
+   </td>
+   <td style="background-color: #f3f3f3">0.55
+   </td>
+   <td style="background-color: #f3f3f3">137.5
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">TorchCheckpointIO (Local SSD)
    </td>
    <td style="background-color: #d9d9d9">100
    </td>
    <td style="background-color: #d9d9d9">298
    </td>
-   <td style="background-color: #d9d9d9">2.87
+   <td style="background-color: #d9d9d9">2.02
    </td>
-   <td style="background-color: #d9d9d9">103.98
-   </td>
-  </tr>
-  <tr>
-   <td style="background-color: #f3f3f3">Dataflux
-   </td>
-   <td style="background-color: #f3f3f3">100
-   </td>
-   <td style="background-color: #f3f3f3">298
-   </td>
-   <td style="background-color: #f3f3f3">2.97
-   </td>
-   <td style="background-color: #f3f3f3">100.33
+   <td style="background-color: #d9d9d9">147.5
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9"> Default
+   <td style="background-color: #d9d9d9">TorchCheckpointIO (gcsfs)
    </td>
-   <td style="background-color: #d9d9d9">1000
+   <td style="background-color: #d9d9d9">100
    </td>
-   <td style="background-color: #d9d9d9">2500
+   <td style="background-color: #d9d9d9">298
    </td>
-   <td style="background-color: #d9d9d9">25.61
+   <td style="background-color: #d9d9d9">3.38
    </td>
-   <td style="background-color: #d9d9d9">97.61
+   <td style="background-color: #d9d9d9">88.2
    </td>
   </tr>
   <tr>
-   <td style="background-color: #f3f3f3">Dataflux
+   <td style="background-color: #d9d9d9">Dataflux (Transfer Manager Disabled)
+   </td>
+   <td style="background-color: #d9d9d9">100
+   </td>
+   <td style="background-color: #d9d9d9">298
+   </td>
+   <td style="background-color: #d9d9d9">3.16
+   </td>
+   <td style="background-color: #d9d9d9">94.3
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">Dataflux (Transfer Manager Enabled)
+   </td>
+   <td style="background-color: #d9d9d9">100
+   </td>
+   <td style="background-color: #d9d9d9">298
+   </td>
+   <td style="background-color: #d9d9d9">1.19
+   </td>
+   <td style="background-color: #d9d9d9">250.4
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">TorchCheckpointIO (Local SSD)
    </td>
    <td style="background-color: #f3f3f3">1000
    </td>
    <td style="background-color: #f3f3f3">2500
    </td>
-   <td style="background-color: #f3f3f3">24.17
+   <td style="background-color: #f3f3f3">24.05
    </td>
-   <td style="background-color: #f3f3f3">103.43
+   <td style="background-color: #f3f3f3">104.0
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">TorchCheckpointIO (gcsfs)
+   </td>
+   <td style="background-color: #f3f3f3">1000
+   </td>
+   <td style="background-color: #f3f3f3">2500
+   </td>
+   <td style="background-color: #f3f3f3">32.44
+   </td>
+   <td style="background-color: #f3f3f3">77.1
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux (Transfer Manager Disabled)
+   </td>
+   <td style="background-color: #f3f3f3">1000
+   </td>
+   <td style="background-color: #f3f3f3">2500
+   </td>
+   <td style="background-color: #f3f3f3">27.48
+   </td>
+   <td style="background-color: #f3f3f3">91.0
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux (Transfer Manager Enabled)
+   </td>
+   <td style="background-color: #f3f3f3">1000
+   </td>
+   <td style="background-color: #f3f3f3">2500
+   </td>
+   <td style="background-color: #f3f3f3">7.74
+   </td>
+   <td style="background-color: #f3f3f3">323.0
+   </td>
+  </tr>
+</table>
+
+### Loading Checkpoints
+
+<table>
+  <tr>
+   <td style="background-color: #d9d2e9"><strong>Checkpoint Type</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Layers</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Checkpoint Size (MB) per step</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Average Checkpoint Load Time</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Read Throughput (MB/s)</strong>
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">TorchCheckpointIO (Local SSD)
+   </td>
+   <td style="background-color: #f3f3f3">10
+   </td>
+   <td style="background-color: #f3f3f3">75.6
+   </td>
+   <td style="background-color: #f3f3f3">0.03
+   </td>
+   <td style="background-color: #f3f3f3">2520.0
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">TorchCheckpointIO (gcsfs)
+   </td>
+   <td style="background-color: #f3f3f3">10
+   </td>
+   <td style="background-color: #f3f3f3">75.6
+   </td>
+   <td style="background-color: #f3f3f3">2.38
+   </td>
+   <td style="background-color: #f3f3f3">31.8
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux (Transfer Manager Disabled)
+   </td>
+   <td style="background-color: #f3f3f3">10
+   </td>
+   <td style="background-color: #f3f3f3">75.6
+   </td>
+   <td style="background-color: #f3f3f3">2.37
+   </td>
+   <td style="background-color: #f3f3f3">31.9
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux (Transfer Manager Enabled)
+   </td>
+   <td style="background-color: #f3f3f3">10
+   </td>
+   <td style="background-color: #f3f3f3">75.6
+   </td>
+   <td style="background-color: #f3f3f3">0.38
+   </td>
+   <td style="background-color: #f3f3f3">198.9
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">TorchCheckpointIO (Local SSD)
+   </td>
+   <td style="background-color: #d9d9d9">100
+   </td>
+   <td style="background-color: #d9d9d9">298
+   </td>
+   <td style="background-color: #d9d9d9">0.18
+   </td>
+   <td style="background-color: #d9d9d9">1655.6
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">TorchCheckpointIO (gcsfs)
+   </td>
+   <td style="background-color: #d9d9d9">100
+   </td>
+   <td style="background-color: #d9d9d9">298
+   </td>
+   <td style="background-color: #d9d9d9">12.00
+   </td>
+   <td style="background-color: #d9d9d9">24.8
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">Dataflux (Transfer Manager Disabled)
+   </td>
+   <td style="background-color: #d9d9d9">100
+   </td>
+   <td style="background-color: #d9d9d9">298
+   </td>
+   <td style="background-color: #d9d9d9">8.44
+   </td>
+   <td style="background-color: #d9d9d9">35.3
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">Dataflux (Transfer Manager Enabled)
+   </td>
+   <td style="background-color: #d9d9d9">100
+   </td>
+   <td style="background-color: #d9d9d9">298
+   </td>
+   <td style="background-color: #d9d9d9">1.72
+   </td>
+   <td style="background-color: #d9d9d9">173.3
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">TorchCheckpointIO (Local SSD)
+   </td>
+   <td style="background-color: #f3f3f3">1000
+   </td>
+   <td style="background-color: #f3f3f3">2500
+   </td>
+   <td style="background-color: #f3f3f3">2.14
+   </td>
+   <td style="background-color: #f3f3f3">1168.2
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">TorchCheckpointIO (gcsfs)
+   </td>
+   <td style="background-color: #f3f3f3">1000
+   </td>
+   <td style="background-color: #f3f3f3">2500
+   </td>
+   <td style="background-color: #f3f3f3">174.40
+   </td>
+   <td style="background-color: #f3f3f3">14.33
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux (Transfer Manager Disabled)
+   </td>
+   <td style="background-color: #f3f3f3">1000
+   </td>
+   <td style="background-color: #f3f3f3">2500
+   </td>
+   <td style="background-color: #f3f3f3">77.92
+   </td>
+   <td style="background-color: #f3f3f3">32.1
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux (Transfer Manager Enabled)
+   </td>
+   <td style="background-color: #f3f3f3">1000
+   </td>
+   <td style="background-color: #f3f3f3">2500
+   </td>
+   <td style="background-color: #f3f3f3">12.87
+   </td>
+   <td style="background-color: #f3f3f3">194.3
    </td>
   </tr>
 </table>

--- a/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
@@ -16,9 +16,11 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         self,
         project_name: str,
         storage_client: Optional[storage.Client] = None,
+        use_transfer_manager: bool = True,
     ):
         self.project_name = project_name
         self.storage_client = storage_client
+        self.use_transfer_manager = use_transfer_manager
         if not storage_client:
             self.storage_client = storage.Client(project=self.project_name, )
         user_agent.add_dataflux_user_agent(self.storage_client)
@@ -64,11 +66,14 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         bucket_name, key = self._parse_gcs_path(path)
         bucket_client = self.storage_client.bucket(bucket_name)
         blob = bucket_client.blob(key)
-        with tempfile.NamedTemporaryFile(mode="w+b") as file:
-            torch.save(checkpoint, file)
-            transfer_manager.upload_chunks_concurrently(filename=file.name,
-                                                        blob=blob,
-                                                        worker_type='thread')
+        if self.use_transfer_manager:
+            with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as file:
+                torch.save(checkpoint, file)
+                transfer_manager.upload_chunks_concurrently(
+                    filename=file.name, blob=blob, worker_type='thread')
+                return
+        with blob.open("wb", ignore_flush=True) as blobwriter:
+            torch.save(checkpoint, blobwriter)
 
     def load_checkpoint(
         self,
@@ -78,6 +83,11 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         bucket_name, key = self._parse_gcs_path(path)
         bucket_client = self.storage_client.bucket(bucket_name)
         blob = bucket_client.blob(key)
+        if self.use_transfer_manager:
+            with tempfile.NamedTemporaryFile(mode="w+b", delete=True) as file:
+                transfer_manager.download_chunks_concurrently(
+                    blob=blob, filename=file.name, worker_type='thread')
+                return torch.load(file, map_location)
         return torch.load(blob.open("rb"), map_location)
 
     def remove_checkpoint(

--- a/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
@@ -1,5 +1,6 @@
+import io
 from pathlib import Path
-from typing import Any, Dict, Optional, Union, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 from dataflux_core import user_agent
@@ -62,8 +63,9 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         bucket_name, key = self._parse_gcs_path(path)
         bucket_client = self.storage_client.bucket(bucket_name)
         blob = bucket_client.blob(key)
-        with blob.open("wb", ignore_flush=True) as blobwriter:
-            torch.save(checkpoint, blobwriter)
+        with io.BytesIO() as stream:
+            torch.save(checkpoint, stream)
+            blob.upload_from_file(stream, rewind=True)
 
     def load_checkpoint(
         self,

--- a/dataflux_pytorch/tests/test_dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/tests/test_dataflux_lightning_checkpoint.py
@@ -1,6 +1,7 @@
 import unittest
-from typing import Any, Dict
 from pathlib import Path
+from typing import Any, Dict
+
 import torch
 
 from dataflux_client_python.dataflux_core.tests import fake_gcs
@@ -20,8 +21,10 @@ class LightningCheckpointTestCase(unittest.TestCase):
         self.ckpt = DatafluxLightningCheckpoint(
             project_name=self.project_name,
             storage_client=client,
+            # Transfer Manager makes its own HTTP calls so it doesn't work with the fake
+            use_transfer_manager=False,
         )
-        self.bucket = fake_gcs.Bucket("fake_bucket")
+        self.bucket = client.bucket("fake_bucket")
 
     def test_invalid_string_path_save(self):
         ckpt_path = "fake_bucket/checkpoint.ckpt"


### PR DESCRIPTION
This speeds up checkpointing so that our implementation is much faster than gcsfs & the previous implementation since we're using Transfer Manager to parallelize uploads and downloads.

I've updated the benchmark numbers, as well as updating the benchmark to also record checkpoint load times. 

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR