### PR TITLE
Faster Lightning Checkpoint download

### DIFF
--- a/dataflux_pytorch/benchmark/README.md
+++ b/dataflux_pytorch/benchmark/README.md
@@ -1,6 +1,6 @@
 # Benchmarking PyTorch Lightning Checkpoints with Google Cloud Storage
 
-This benchmarking script will allow you to run and benchmark the performance of the PyTorch Lightning Checkpoint save function. This script does not rely on GPUs, TPUs or CPU Clusters and can be run directly on your machine. The script runs the `WikiText2` PyTorch Lightning demo code with some modifications.
+This benchmarking script will allow you to run and benchmark the performance of the PyTorch Lightning Checkpoint save/load function. This script does not rely on GPUs, TPUs or CPU Clusters and can be run directly on your machine. The script runs the `WikiText2` PyTorch Lightning demo code with some modifications.
 
 ## Getting started
 
@@ -20,7 +20,7 @@ gcloud config set project {PROJECT_ID}
 
 Then set the enviroment variables.
 
-`CKPT_DIR_PATH` is the location of where to save the checkpoints. `STEPS` is the number of steps the model will take (the number of checkpoints created will be the same). The default value for `STEPS` is 5. The benchmark will run `save_checkpoint` repeatedly and produce the average at the end.
+`CKPT_DIR_PATH` is the location of where to save the checkpoints. `STEPS` is the number of steps the model will take (the number of checkpoints created will be the same). The default value for `STEPS` is 5. The benchmark will run `save_checkpoint` repeatedly and produce the average at the end, then run `load_checkpoint` on all the saved checkpoints and produce the average.
 
 ```shell
 export CKPT_DIR_PATH=`gs://path/to/directory/`
@@ -71,14 +71,17 @@ HPU available: False, using: 0 HPUs
 Epoch 0:   0%|                                                                                                            | 10/59674 [12:17<1221:29:06,  0.01it/s, v_num=5]`Trainer.fit` stopped: `max_steps=10` reached.
 Epoch 0:   0%|                                                                                                            | 10/59674 [12:17<1221:29:09,  0.01it/s, v_num=5]
 Average time to save one checkpoint: 58.68560411930084 seconds
+Average time to load one checkpoint: 62.54739844375839 seconds
 ```
 
 ## Results
 
-The table below contains benchmarking times on saving checkpoints to GCS, the average save time is taken over 10 calls to save_checkpoint. The tests were done from a VM with 48vCPU, 192 GB RAM, 512 GB SSD located in `us-west1-a` zone. The GCS bucket was located in the same region, `us-west1`.
+The table below contains benchmarking times on saving checkpoints to GCS, the average save/load time is taken over 10 calls to save_checkpoint and load_checkpoint. The tests were done from a VM with 48vCPU, 192 GB RAM, 512 GB SSD located in `us-west1-a` zone. The GCS bucket was located in the same region, `us-west1`.
 
 
-Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing active development. The numbers below will be continuously updated to reflect the current state and performance of Dataflux's PyTorch Lightning checkpoint utility. These values are compared to `Default`, which refers to fsspec.
+Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing active development. The numbers below will be continuously updated to reflect the current state and performance of Dataflux's PyTorch Lightning checkpoint utility. These values are compared to `Default`, which refers to the default `TorchCheckpointIO` with fsspec/gcsfs.
+
+### Checkpoint Save
 
 <table>
   <tr>
@@ -94,7 +97,7 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9"> Default
+   <td style="background-color: #d9d9d9">Default
    </td>
    <td style="background-color: #d9d9d9">10
    </td>
@@ -142,7 +145,7 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    </td>
   </tr>
   <tr>
-   <td style="background-color: #d9d9d9"> Default
+   <td style="background-color: #d9d9d9">Default
    </td>
    <td style="background-color: #d9d9d9">1000
    </td>
@@ -163,6 +166,95 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    <td style="background-color: #f3f3f3">24.17
    </td>
    <td style="background-color: #f3f3f3">103.43
+   </td>
+  </tr>
+</table>
+
+### Checkpoint Load
+
+<table>
+  <tr>
+   <td style="background-color: #d9d2e9"><strong>Checkpoint Type</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Layers</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Checkpoint Size (MB) per step</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Average Checkpoint Save Time</strong>
+   </td>
+   <td style="background-color: #d9d2e9"><strong>Read Throughput (MB/s)</strong>
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">Default
+   </td>
+   <td style="background-color: #d9d9d9">10
+   </td>
+   <td style="background-color: #d9d9d9">75.6
+   </td>
+   <td style="background-color: #d9d9d9">2.38
+   </td>
+   <td style="background-color: #d9d9d9">31.76
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux
+   </td>
+   <td style="background-color: #f3f3f3">10
+   </td>
+   <td style="background-color: #f3f3f3">75.6
+   </td>
+   <td style="background-color: #f3f3f3">0.51
+   </td>
+   <td style="background-color: #f3f3f3">148.24
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">Default
+   </td>
+   <td style="background-color: #d9d9d9">100
+   </td>
+   <td style="background-color: #d9d9d9">298
+   </td>
+   <td style="background-color: #d9d9d9">12.83
+   </td>
+   <td style="background-color: #d9d9d9">23.23
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux
+   </td>
+   <td style="background-color: #f3f3f3">100
+   </td>
+   <td style="background-color: #f3f3f3">298
+   </td>
+   <td style="background-color: #f3f3f3">1.69
+   </td>
+   <td style="background-color: #f3f3f3">176.33
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #d9d9d9">Default
+   </td>
+   <td style="background-color: #d9d9d9">1000
+   </td>
+   <td style="background-color: #d9d9d9">2500
+   </td>
+   <td style="background-color: #d9d9d9">186.57
+   </td>
+   <td style="background-color: #d9d9d9">13.40
+   </td>
+  </tr>
+  <tr>
+   <td style="background-color: #f3f3f3">Dataflux
+   </td>
+   <td style="background-color: #f3f3f3">1000
+   </td>
+   <td style="background-color: #f3f3f3">2500
+   </td>
+   <td style="background-color: #f3f3f3">14.77
+   </td>
+   <td style="background-color: #f3f3f3">169.26
    </td>
   </tr>
 </table>

--- a/dataflux_pytorch/benchmark/README.md
+++ b/dataflux_pytorch/benchmark/README.md
@@ -180,7 +180,7 @@ Dataflux's implementation of CheckpointIO for PyTorch Lightning is undergoing ac
    </td>
    <td style="background-color: #d9d2e9"><strong>Checkpoint Size (MB) per step</strong>
    </td>
-   <td style="background-color: #d9d2e9"><strong>Average Checkpoint Save Time</strong>
+   <td style="background-color: #d9d2e9"><strong>Average Checkpoint Restore Time</strong>
    </td>
    <td style="background-color: #d9d2e9"><strong>Read Throughput (MB/s)</strong>
    </td>

--- a/dataflux_pytorch/benchmark/lightning_checkpoint_benchmark.py
+++ b/dataflux_pytorch/benchmark/lightning_checkpoint_benchmark.py
@@ -45,7 +45,6 @@ def main(project: str,
          ckpt_dir_path: str,
          save_only_latest: bool,
          dataflux_ckpt: bool,
-         use_transfer_manager: bool,
          layers: int = 100,
          steps: int = 5):
     """Checkpoints a PyTorch Ligthning demo model to GCS using gcsfs or DatafluxLightningCheckpoint.
@@ -90,8 +89,7 @@ def main(project: str,
     model = LightningTransformer(vocab_size=dataset.vocab_size, nlayers=layers)
     ckpt = TorchCheckpointIO()
     if dataflux_ckpt:
-        ckpt = DatafluxLightningCheckpoint(
-            project_name=project, use_transfer_manager=use_transfer_manager)
+        ckpt = DatafluxLightningCheckpoint(project_name=project)
     # Save once per step, and if `save_only_latest`, replace the last checkpoint each time.
     # Replacing is implemented by saving the new checkpoint, and then deleting the previous one.
     # If `save_only_latest` is False, a new checkpoint is created for each step.
@@ -120,7 +118,8 @@ def main(project: str,
           str((end - start) / steps) + " seconds")
     start = time.time()
     for i in range(steps):
-        ckpt.load_checkpoint(os.path.join(ckpt_dir_path, f'ckpt_{i}.ckpt'))
+        data = ckpt.load_checkpoint(
+            os.path.join(ckpt_dir_path, f'ckpt_{i}.ckpt'))
     end = time.time()
     print("Average time to load one checkpoint: " +
           str((end - start) / steps) + " seconds")
@@ -138,7 +137,6 @@ if __name__ == "__main__":
         os.getenv("CKPT_DIR_PATH"),
         os.getenv("SAVE_ONLY_LATEST") == "1",
         os.getenv("DATAFLUX_CKPT") == "1",
-        os.getenv("USE_TRANSFER_MANAGER") == "1",
         layers,
         steps,
     )

--- a/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
@@ -1,5 +1,6 @@
+import io
 from pathlib import Path
-from typing import Any, Dict, Optional, Union, Tuple
+from typing import Any, Dict, Optional, Tuple, Union
 
 import torch
 from dataflux_core import user_agent
@@ -14,9 +15,11 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         self,
         project_name: str,
         storage_client: Optional[storage.Client] = None,
+        use_transfer_manager: bool = False,
     ):
         self.project_name = project_name
         self.storage_client = storage_client
+        self.use_transfer_manager = use_transfer_manager
         if not storage_client:
             self.storage_client = storage.Client(project=self.project_name, )
         user_agent.add_dataflux_user_agent(self.storage_client)
@@ -73,7 +76,12 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         bucket_name, key = self._parse_gcs_path(path)
         bucket_client = self.storage_client.bucket(bucket_name)
         blob = bucket_client.blob(key)
-        return torch.load(blob.open("rb"), map_location)
+        if not self.use_transfer_manager:
+            return torch.load(blob.open("rb"), map_location)
+        stream = io.BytesIO()
+        blob.download_to_file(stream)
+        stream.seek(0)
+        return torch.load(stream, map_location)
 
     def remove_checkpoint(
         self,

--- a/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
+++ b/dataflux_pytorch/lightning/dataflux_lightning_checkpoint.py
@@ -15,11 +15,9 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         self,
         project_name: str,
         storage_client: Optional[storage.Client] = None,
-        use_transfer_manager: bool = False,
     ):
         self.project_name = project_name
         self.storage_client = storage_client
-        self.use_transfer_manager = use_transfer_manager
         if not storage_client:
             self.storage_client = storage.Client(project=self.project_name, )
         user_agent.add_dataflux_user_agent(self.storage_client)
@@ -76,8 +74,6 @@ class DatafluxLightningCheckpoint(CheckpointIO):
         bucket_name, key = self._parse_gcs_path(path)
         bucket_client = self.storage_client.bucket(bucket_name)
         blob = bucket_client.blob(key)
-        if not self.use_transfer_manager:
-            return torch.load(blob.open("rb"), map_location)
         stream = io.BytesIO()
         blob.download_to_file(stream)
         stream.seek(0)


### PR DESCRIPTION
This uses the Python Client Library's `blob.download_to_file` function to make checkpoint download quicker than passing the blob's reader to `torch.load` directly. 

* Benchmarked performance and added it to the README. The previous implementation performed similarly to the `Default`  (fsspec) numbers there
* Updated the benchmark to benchmark both checkpoint save and restore performance

- [x] Tests pass (pending https://github.com/GoogleCloudPlatform/dataflux-client-python/pull/64, will update once that's merged)
- [x] Appropriate changes to documentation are included in the PR