### PR TITLE
Adding GCS Custom reader

### DIFF
--- a/dataflux_pytorch/lightning/__init__.py
+++ b/dataflux_pytorch/lightning/__init__.py
@@ -1,5 +1,5 @@
 from .dataflux_lightning_checkpoint import DatafluxLightningCheckpoint
-from .gcs_filesystem import GCSFileSystem, GCSDistributedWriter
+from .gcs_filesystem import GCSFileSystem, GCSDistributedWriter, GCSDistributedReader
 
 __all__ = ["DatafluxLightningCheckpoint",
-           "GCSFileSystem", "GCSDistributedWriter"]
+           "GCSFileSystem", "GCSDistributedWriter", "GCSDistributedReader"]

--- a/dataflux_pytorch/lightning/gcs_filesystem.py
+++ b/dataflux_pytorch/lightning/gcs_filesystem.py
@@ -6,7 +6,7 @@ from typing import Generator, Optional, Union, cast
 
 from dataflux_core import user_agent
 from google.cloud import storage
-from torch.distributed.checkpoint import FileSystemWriter
+from torch.distributed.checkpoint import FileSystemWriter, FileSystemReader
 from torch.distributed.checkpoint.filesystem import FileSystemBase
 from dataflux_pytorch.lightning.path_utils import parse_gcs_path
 
@@ -28,9 +28,18 @@ class GCSFileSystem(FileSystemBase):
     def create_stream(self, path: Union[str, os.PathLike],
                       mode: str) -> Generator[io.IOBase, None, None]:
         bucket, path = parse_gcs_path(path)
-        with self.storage_client.bucket(bucket).blob(path).open(
-                "wb", ignore_flush=True) as stream:
-            yield cast(io.IOBase, stream)
+        if mode == "wb":  # write mode.
+            with self.storage_client.bucket(bucket).blob(path).open(
+                    "wb", ignore_flush=True) as stream:
+                yield cast(io.IOBase, stream)
+        elif mode == "rb":  # read mode.
+            bucket_client = self.storage_client.bucket(bucket)
+            blob = bucket_client.blob(path)
+            blob_data = blob.download_as_bytes()
+            yield io.BytesIO(blob_data)
+        else:
+            raise ValueError(
+                "Invalid mode argument, create_stream only supports rb (read mode) & wb (write mode)")
 
     def concat_path(self, path: Union[str, os.PathLike],
                     suffix: str) -> Union[str, os.PathLike]:
@@ -88,3 +97,11 @@ class GCSDistributedWriter(FileSystemWriter):
         super().__init__(path, **kwargs)
         self.fs = GCSFileSystem(project_name, storage_client)
         self.sync_files = False
+
+
+class GCSDistributedReader(FileSystemReader):
+    def __init__(self, path: Union[str, os.PathLike],
+                 project_name: str,
+                 storage_client: Optional[storage.Client] = None):
+        super().__init__(path=path)
+        self.fs = GCSFileSystem(project_name, "read", storage_client)

--- a/dataflux_pytorch/tests/test_dataflux_lightning_gcs_filesystem.py
+++ b/dataflux_pytorch/tests/test_dataflux_lightning_gcs_filesystem.py
@@ -29,15 +29,46 @@ class GCSFileSystemTestCase(unittest.TestCase):
             with self.fake_gcs.create_stream(path, "wb") as stream:
                 pass
 
-    def test_create_stream_valid_path_string(self):
+    def test_create_stream_valid_path_string_write_mode(self):
         path = f'gs://{self.bucket_name}/some-dir/'
         with self.fake_gcs.create_stream(path, "wb") as stream:
             pass
 
-    def test_create_stream_valid_path_object(self):
+    def test_create_stream_valid_path_object_write_mode(self):
         path = Path(f'gs://{self.bucket_name}/some-dir/')
         with self.fake_gcs.create_stream(path, "wb") as stream:
             pass
+
+    def test_create_stream_valid_path_string_read_mode(self):
+        path = f'gs://{self.bucket_name}/some-dir/'
+        with self.fake_gcs.create_stream(path, "rb") as stream:
+            pass
+
+    def test_create_stream_valid_path_object_read_mode(self):
+        path = Path(f'gs://{self.bucket_name}/some-dir/')
+        with self.fake_gcs.create_stream(path, "rb") as stream:
+            pass
+
+    def test_create_stream_valid_path_object_invalid_mode(self):
+        path = Path(f'gs://{self.bucket_name}/some-dir/')
+        with self.assertRaises(ValueError) as context:
+            with self.fake_gcs.create_stream(path, "invalid_mode"):
+                pass
+
+        self.assertEqual(
+            str(context.exception),
+            "Invalid mode argument, create_stream only supports rb (read mode) & wb (write mode)"
+        )
+
+    def test_create_stream_valid_path_string_invalid_mode(self):
+        path = f'gs://{self.bucket_name}/some-dir/'
+        with self.assertRaises(ValueError) as context:
+            with self.fake_gcs.create_stream(path, "invalid_mode"):
+                pass
+        self.assertEqual(
+            str(context.exception),
+            "Invalid mode argument, create_stream only supports rb (read mode) & wb (write mode)"
+        )
 
     def test_concat_path_with_string(self):
         path = "/base/path"


### PR DESCRIPTION
This adds custom GCS Reader to dataflux pytroch. 

Demo  POC is present in yashsha-tp branch (https://github.com/GoogleCloudPlatform/dataflux-pytorch/compare/yashsha-tp?expand=1) . I will add it to demo section after this PR is merged. 

create_stream is called with either "wb" (write binary) https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/filesystem.py#L318 

or "rb"(read binary) mode https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/filesystem.py#L643 & https://github.com/pytorch/pytorch/blob/main/torch/distributed/checkpoint/filesystem.py#L679 

In read mode we need to pass Bytes instead of stream of bytes otherwise pickle.load fails. 

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR