### PR TITLE
Remove client initialization for fast listing from dataflux-pytorch

### DIFF
--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -200,7 +200,8 @@ class DataFluxMapStyleDataset(data.Dataset):
                     prefix=self.config.prefix,
                     retry_config=self.config.list_retry_config,
                 )
-                lister.client = self._get_or_create_storage_client()
+                if self.storage_client is not None:
+                    lister.client = self.storage_client
                 listed_objects = lister.run()
 
             except Exception as e:

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -200,6 +200,7 @@ class DataFluxMapStyleDataset(data.Dataset):
                     prefix=self.config.prefix,
                     retry_config=self.config.list_retry_config,
                 )
+                # If the dataset was not initialized with an storage_client, ensure that we do not attach a client to the lister to avoid pickling errors (#58).
                 if self.storage_client is not None:
                     lister.client = self.storage_client
                 listed_objects = lister.run()

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -21,7 +21,7 @@ from unittest import mock
 
 from google.cloud import storage
 
-from dataflux_core.tests import fake_gcs
+from dataflux_client_python.dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_mapstyle_dataset
 
 


### PR DESCRIPTION
To fix [#58](https://github.com/GoogleCloudPlatform/dataflux-pytorch/issues/58)

When multiprocess starts with spawn or forkserver,  passing storage client to fast-listing from dataflux pytorch will result in pickling error. Multi-processing fails as it cannot serialize/pickle storage client. 
- remove storage client creation for fast listing from dataflux_pytorch/dataflux_mapstyle_dataset.py.

The change got add in PR [#109]( https://github.com/GoogleCloudPlatform/dataflux-pytorch/pull/109)

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR