### PR TITLE
Fixing build failures

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/singlenode/README.md
+++ b/dataflux_pytorch/benchmark/checkpointing/singlenode/README.md
@@ -39,7 +39,7 @@ Then set the command line variables.
 `--enable-multipart`: To run with experimental multipart upload performance improvements. This flag leverages parallel upload to dramatically improve the upload speed of checkpoint saves.
 
 ```shell
-python dataflux_pytorch/benchmark/lightning_checkpoint_benchmark.py --enable-multipart --project=my-project --ckpt-dir-path=gs://my-bucket/path/to/dir/ --layers=10 --steps=5
+python dataflux_pytorch/benchmark/checkpointing/singlenode/train.py --enable-multipart --project=my-project --ckpt-dir-path=gs://my-bucket/path/to/dir/ --layers=10 --steps=5
 ```
 
 To run the script without multipart upload, simply omit the flag.
@@ -52,7 +52,7 @@ python dataflux_pytorch/benchmark/checkpointing/singlenode/train.py --project=my
 The time will print out and the checkpoints can be viewed in GCS at the location passed in. A sample output is shown below.
 
 ```shell
-$ python dataflux_pytorch/benchmark/lightning_checkpoint_benchmark.py
+$ python dataflux_pytorch/benchmark/checkpointing/singlenode/train.py
 GPU available: False, used: False
 TPU available: False, using: 0 TPU cores
 HPU available: False, using: 0 HPUs

--- a/dataflux_pytorch/benchmark/checkpointing/singlenode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/singlenode/train.py
@@ -73,8 +73,8 @@ def parse_args():
     parser.add_argument("--enable-multipart",
                         action="store_true",
                         default=False)
-    parser.add_argument("--clear-kernel-cache", 
-                        action="store_true", 
+    parser.add_argument("--clear-kernel-cache",
+                        action="store_true",
                         default=False)
     return parser.parse_args()
 
@@ -93,11 +93,11 @@ def main():
 
       Run DatafluxLightningCheckpoint over 10 steps:
 
-      python3 lightning_checkpoint_benchmark.py --project=my-project --ckpt_dir_path=gs://bucket-name/path/to/dir/ --save_only_latest --layers=1000 --steps=10
+      python3 train.py --project=my-project --ckpt_dir_path=gs://bucket-name/path/to/dir/ --save_only_latest --layers=1000 --steps=10
 
       Run gcsfs over 10 steps:
 
-      python3 lightning_checkpoint_benchmark.py --project=my-project --ckpt_dir_path=gs://bucket-name/path/to/dir/ --layers=1000 --steps=10 --no-dataflux-ckpt
+      python3 train.py --project=my-project --ckpt_dir_path=gs://bucket-name/path/to/dir/ --layers=1000 --steps=10 --no-dataflux-ckpt
 
     """
     args = parse_args()

--- a/kokoro/bench.sh
+++ b/kokoro/bench.sh
@@ -67,7 +67,7 @@ function run_benchmarks(){
     echo Running image-segmentation benchmark.
     python3 -u ./demo/lightning/image-segmentation/train.py --local --benchmark --gcp_project=dataflux-project --gcs_bucket=dataflux-demo-public --images_prefix=image-segmentation-dataset/images --labels_prefix=image-segmentation-dataset/labels --num_nodes=1 --num_devices=5 --epochs=2;
     echo Running single node checkpointing benchmark.
-    python3 -u ./dataflux_pytorch/benchmark/lightning_checkpoint_benchmark.py --enable-multipart --project=dataflux-project --ckpt-dir-path=gs://df-ckpt-presubmit/ --layers=1000 --steps=5
+    python3 -u ./dataflux_pytorch/benchmark/checkpointing/multinode/train.py --enable-multipart --project=dataflux-project --ckpt-dir-path=gs://df-ckpt-presubmit/ --layers=1000 --steps=5
 }
 
 setup_virtual_envs


### PR DESCRIPTION
Got a failure in continuous benchmark test, seems like PR to add single node benchmarking to continuous runs was raised after I raised [PR#121 ](https://github.com/GoogleCloudPlatform/dataflux-pytorch/pull/121). 

Replaced all instances of `lightning_checkpoint_benchmark.py` with `checkpointing/singlenode/train.py`

- [X] Tests pass
- [X] Appropriate changes to documentation are included in the PR