### PR TITLE
update default dataflux to use multipart

### DIFF
--- a/dataflux_pytorch/dataflux_checkpoint.py
+++ b/dataflux_pytorch/dataflux_checkpoint.py
@@ -14,14 +14,17 @@
  limitations under the License.
  """
 
+from io import BytesIO
 from typing import Optional
 
 from dataflux_core import user_agent
+from dataflux_pytorch.multipart_upload.multipart import \
+    upload_chunks_concurrently_from_bytesio as upload
 from google.cloud import storage
 from google.cloud.storage.fileio import BlobReader, BlobWriter
 
 
-class DatafluxCheckpoint:
+class DatafluxCheckpoint():
     """Implements the interface of saving and loading model checkpoints.
 
     The reader and writer return a BlobReader and BlobWriter respectively, which
@@ -58,4 +61,25 @@ class DatafluxCheckpoint:
 
     def writer(self, object_name: str) -> BlobWriter:
         blob = self.bucket.blob(object_name)
-        return blob.open("wb", ignore_flush=True)
+        return DatafluxCheckpointBuffer(blob)
+
+
+class DatafluxCheckpointBuffer(BytesIO):
+    """Implements a BytesIO buffer that will flush to GCS.
+
+    This class overrides the flush function of BytesIO to perform
+    an optimized multipart upload directly to a specified GCS bucket.
+    """
+
+    def __init__(self, blob: "google.cloud.storage.blob.Blob"):
+        """Initializes the DatafluxCheckpointBuffer
+
+        Args:
+            blob: A GCS blob to which the checkpoint will be uploaded.
+        """
+        self.blob = blob
+        super().__init__()
+
+    def flush(self):
+        super().flush()
+        upload(self, self.blob)

--- a/dataflux_pytorch/tests/test_dataflux_checkpoint.py
+++ b/dataflux_pytorch/tests/test_dataflux_checkpoint.py
@@ -19,6 +19,7 @@ import unittest
 
 from dataflux_client_python.dataflux_core.tests import fake_gcs
 from dataflux_pytorch import dataflux_checkpoint
+from unittest import mock
 
 
 class CheckpointTestCase(unittest.TestCase):
@@ -45,10 +46,22 @@ class CheckpointTestCase(unittest.TestCase):
 
     def test_writer(self):
         got_writer = self.ckpt.writer(self.object_name)
-        self.assertIsInstance(got_writer, fake_gcs.FakeBlobWriter)
+        self.assertIsInstance(got_writer,
+                              dataflux_checkpoint.DatafluxCheckpointBuffer)
         self.assertTrue(
             self.ckpt.storage_client._connection.user_agent.startswith(
                 "dataflux"))
+
+    def test_df_checkpoint_buffer_init(self):
+        buffer = self.ckpt.writer(self.object_name)
+        self.assertEqual(buffer.blob.name, self.object_name)
+
+    @mock.patch("dataflux_pytorch.dataflux_checkpoint.upload")
+    def test_df_checkpoint_buffer_flush(self, mock_upload):
+        buffer = self.ckpt.writer(self.object_name)
+        buffer.flush()
+        buffer.flush()
+        self.assertEqual(mock_upload.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR creates a simple wrapped bufferIO object that will write to GCS on flush. It should not introduce any differences in the existing method of implementation. I have tested it against the explicit example provided in our README.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR