### PR TITLE
implement fast download for df checkpoint

### DIFF
--- a/dataflux_pytorch/dataflux_checkpoint.py
+++ b/dataflux_pytorch/dataflux_checkpoint.py
@@ -57,7 +57,10 @@ class DatafluxCheckpoint():
 
     def reader(self, object_name: str) -> BlobReader:
         blob = self.bucket.blob(object_name)
-        return blob.open("rb")
+        stream = BytesIO()
+        blob.download_to_file(stream)
+        stream.seek(0)
+        return stream
 
     def writer(self, object_name: str) -> BlobWriter:
         blob = self.bucket.blob(object_name)


### PR DESCRIPTION
Update non-lightning dataflux to use blob.download_to_file for increased performance. This code has been tested against the README implementation for verification. This introduces no real change as the returned object is still a bytes buffer.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR