### PR TITLE
Add single node async benchmark execution to integration tests

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/singlenode/README.md
+++ b/dataflux_pytorch/benchmark/checkpointing/singlenode/README.md
@@ -32,7 +32,9 @@ Then set the command line variables.
 
 ### Dataflux Lightning Checkpoint
 
-`--no-dataflux-ckpt`: If you are not benchmarking Dataflux Lightning Checkpoint, this will disable dataflux checkpointing and use the default lightning checkpointing instead. 
+`--checkpoint=no-dataflux`: If you are not benchmarking Dataflux Lightning Checkpoint, this will disable dataflux checkpointing and use the default lightning checkpointing instead. 
+
+`--checkpoint=asynccheckpointio`: This flag will enable asynchronous calls to `save_checkpoint` which will optimize CPU/GPU utilization by making save calls non-blocking. 
 
 `--disable-multipart`: This flag will disable multipart upload performance improvements. In most cases this will dramatically reduce the upload speed of checkpoint saves and is not recommended.
 

--- a/kokoro/bench.sh
+++ b/kokoro/bench.sh
@@ -68,6 +68,8 @@ function run_benchmarks(){
     python3 -u ./demo/lightning/image-segmentation/train.py --local --benchmark --gcp_project=dataflux-project --gcs_bucket=dataflux-demo-public --images_prefix=image-segmentation-dataset/images --labels_prefix=image-segmentation-dataset/labels --num_nodes=1 --num_devices=5 --epochs=2;
     echo Running single node checkpointing benchmark.
     python3 -u ./dataflux_pytorch/benchmark/checkpointing/singlenode/train.py --project=dataflux-project --ckpt-dir-path=gs://df-ckpt-presubmit/ --layers=1000 --steps=5
+    echo Running single node async checkpointing benchmark.
+    python3 -u ./dataflux_pytorch/benchmark/checkpointing/singlenode/train.py --project=dataflux-project --ckpt-dir-path=gs://df-ckpt-presubmit/ --layers=1000 --steps=5 --checkpoint=asynccheckpointio
 }
 
 setup_virtual_envs


### PR DESCRIPTION
This also refactors the flag for no-dataflux since that option is mutually exclusive with the other checkpoint save options.

Internal issue: b/369839708

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR