### PR TITLE
Fix AsyncCheckpointIO race condition

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/singlenode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/singlenode/train.py
@@ -39,6 +39,10 @@ class BenchmarkDatafluxLightningAsyncCheckpoint(
         # Prevent parent teardown from terminating the executor after fit.
         pass
 
+    def finalize(self, *args, **kwargs):
+        # Provide a different invocation of the teardown process.
+        super().teardown()
+
 
 class LightningTransformer(LightningModule):
 
@@ -165,6 +169,10 @@ def main():
         os.system("sync && sudo sysctl -w vm.drop_caches=3")
     print("Average time to save one checkpoint: " +
           str((end - start) / args.steps) + " seconds")
+
+    # If using async, call finalize to shut down the threadpool executor.
+    if args.checkpoint == 'asynccheckpointio':
+        ckpt.finalize()
 
     # Measure load checkpoint.
     start = time.time()


### PR DESCRIPTION
Provide a mechanism for calling Checkpoint teardown when using manual checkpoint saves with AsyncCheckpointIO.

When using a large layer count, the `save_checkpoint()` task was not completing prior to calling `load_checkpoint()`, resulting in a race condition where `load_checkpoint()` would return a 404. This was caused by the removal of the teardown step, which issues a blocking shutdown call to the Threadpool executor, waiting for all tasks to complete before returning. We still want to override teardown so that it is not called during `trainer.fit()`, but we want to make sure the Threadpool tasks complete before making any calls to `load_checkpoint()`.

This PR introduces a new invocation point for the teardown method, which can be called after all `save_checkpoint()` 
 calls and before any `load_checkpoint()` calls.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR