### PR TITLE
add upload and download improvements to multinode

### DIFF
--- a/dataflux_pytorch/dataflux_checkpoint.py
+++ b/dataflux_pytorch/dataflux_checkpoint.py
@@ -70,7 +70,7 @@ class DatafluxCheckpoint():
 class DatafluxCheckpointBuffer(BytesIO):
     """Implements a BytesIO buffer that will flush to GCS.
 
-    This class overrides the flush function of BytesIO to perform
+    This class overrides the close function of BytesIO to perform
     an optimized multipart upload directly to a specified GCS bucket.
     """
 
@@ -83,6 +83,6 @@ class DatafluxCheckpointBuffer(BytesIO):
         self.blob = blob
         super().__init__()
 
-    def flush(self):
-        super().flush()
+    def close(self):
         upload(self, self.blob)
+        super().close()

--- a/dataflux_pytorch/tests/test_dataflux_checkpoint.py
+++ b/dataflux_pytorch/tests/test_dataflux_checkpoint.py
@@ -58,10 +58,9 @@ class CheckpointTestCase(unittest.TestCase):
 
     @mock.patch("dataflux_pytorch.dataflux_checkpoint.upload")
     def test_df_checkpoint_buffer_flush(self, mock_upload):
-        buffer = self.ckpt.writer(self.object_name)
-        buffer.flush()
-        buffer.flush()
-        self.assertEqual(mock_upload.call_count, 2)
+        with self.ckpt.writer(self.object_name) as buffer:
+            pass
+        self.assertEqual(mock_upload.call_count, 1)
 
 
 if __name__ == "__main__":

--- a/dataflux_pytorch/tests/test_dataflux_lightning_gcs_filesystem.py
+++ b/dataflux_pytorch/tests/test_dataflux_lightning_gcs_filesystem.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 from typing import Any, Dict
 from pathlib import Path
 
@@ -7,14 +8,15 @@ from dataflux_pytorch.lightning.gcs_filesystem import GCSFileSystem
 
 
 class GCSFileSystemTestCase(unittest.TestCase):
+
     def setUp(self):
         super().setUp()
         self.project_name = "project_name"
         self.bucket_name = "fake_bucket"
         self.bucket = fake_gcs.Bucket("fake_bucket")
         self.client = fake_gcs.Client()
-        self.fake_gcs = GCSFileSystem(
-            project_name=self.project_name, storage_client=self.client)
+        self.fake_gcs = GCSFileSystem(project_name=self.project_name,
+                                      storage_client=self.client)
 
     def test_create_stream_invalid_path_string(self):
         path = "fake_bucket/checkpoint.ckpt"
@@ -29,12 +31,18 @@ class GCSFileSystemTestCase(unittest.TestCase):
             with self.fake_gcs.create_stream(path, "wb") as stream:
                 pass
 
-    def test_create_stream_valid_path_string_write_mode(self):
+    @mock.patch(
+        "dataflux_pytorch.lightning.gcs_filesystem.DatafluxCheckpointBuffer.close"
+    )
+    def test_create_stream_valid_path_string_write_mode(self, mock_close):
         path = f'gs://{self.bucket_name}/some-dir/'
         with self.fake_gcs.create_stream(path, "wb") as stream:
             pass
 
-    def test_create_stream_valid_path_object_write_mode(self):
+    @mock.patch(
+        "dataflux_pytorch.lightning.gcs_filesystem.DatafluxCheckpointBuffer.close"
+    )
+    def test_create_stream_valid_path_object_write_mode(self, mock_close):
         path = Path(f'gs://{self.bucket_name}/some-dir/')
         with self.fake_gcs.create_stream(path, "wb") as stream:
             pass


### PR DESCRIPTION
Updated GCSFileSystem to use multipart upload and faster download. Updated associated tests, ran locally and against real GPU cluster to validate.

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR