### PR TITLE
Simulated CPU benchmarking code 

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/simulated/multi_node_benchmark.py
+++ b/dataflux_pytorch/benchmark/checkpointing/simulated/multi_node_benchmark.py
@@ -2,11 +2,17 @@ import os
 import socket
 import statistics
 import time
-from typing import Dict
 
 import torch
-import torch.distributed as dist
-from demo.lightning.checkpoint.simulated.multiprocessing_train import BenchmarkStrategy, SimpleModel, format_size, get_tensor_size_bytes, split_tensor, cleanup, time_checkpoint_operation
+from demo.lightning.checkpoint.simulated.multiprocessing_train import (
+    BenchmarkStrategy,
+    SimpleModel,
+    cleanup,
+    format_size,
+    get_tensor_size_bytes,
+    split_tensor,
+    time_checkpoint_operation,
+)
 
 
 def configure_master_addr():

--- a/dataflux_pytorch/benchmark/checkpointing/simulated/multi_node_benchmark.py
+++ b/dataflux_pytorch/benchmark/checkpointing/simulated/multi_node_benchmark.py
@@ -98,7 +98,7 @@ if __name__ == "__main__":
     model_size = int(os.getenv("NUM_LAYERS"))
     project = os.getenv("PROJECT")
     path = os.getenv("CKPT_DIR_PATH")
-    sample_size = int(os.getenv("SAMPLE_SIZE", 3))
+    sample_size = int(os.getenv("SAMPLE_COUNT", 3))
     padding_size = int(os.getenv("PADDING_SIZE", 4000))
     main(world_size, model_size,
          project, path, padding_size, sample_size)

--- a/dataflux_pytorch/benchmark/checkpointing/simulated/multi_node_benchmark.py
+++ b/dataflux_pytorch/benchmark/checkpointing/simulated/multi_node_benchmark.py
@@ -2,52 +2,11 @@ import os
 import socket
 import statistics
 import time
-from typing import Optional, Dict
+from typing import Dict
 
 import torch
 import torch.distributed as dist
-import torch.distributed.checkpoint as dist_cp
-import torch.nn as nn
-from lightning.pytorch.strategies import FSDPStrategy
-from dataflux_pytorch.lightning.gcs_filesystem import GCSDistributedWriter, GCSDistributedReader
-
-
-class BenchmarkStrategy(FSDPStrategy):
-    def __init__(self, project: str, path: str, model: nn.Module, **kwargs) -> None:
-        super().__init__(**kwargs)
-        self.writer = GCSDistributedWriter(path, project, None)
-        self.reader = GCSDistributedReader(path, project, None)
-        self.model = model
-
-    def save_checkpoint(self, checkpoint: Dict[str, torch.Tensor], filepath: str, storage_options: Optional[Dict] = None) -> None:
-        dist_cp.save(state_dict=checkpoint, checkpoint_id=filepath,
-                     storage_writer=self.writer)
-
-    def load_checkpoint(self, checkpoint_path: str) -> None:
-        empty_state_dict = {}
-        dist_cp.load(state_dict=empty_state_dict,
-                     checkpoint_id=checkpoint_path, storage_reader=self.reader)
-
-
-class SimpleModel(nn.Module):
-    def __init__(self, size: int, padding_size: int) -> None:
-        super(SimpleModel, self).__init__()
-        self.fc1 = nn.Linear(size, size)
-        self.fc2 = nn.Linear(size, size)
-        self.dummy_tensors = [torch.randn(size, size)
-                              for _ in range(padding_size)]
-
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.fc2(torch.relu(self.fc1(x)))
-
-
-def format_size(size_bytes: int) -> str:
-    size_mb = size_bytes / (1024 * 1024)
-    return f"{size_mb / 1024:.2f} GB" if size_mb >= 1024 else f"{size_mb:.2f} MB"
-
-
-def get_tensor_size_bytes(tensor: torch.Tensor) -> int:
-    return tensor.element_size() * tensor.numel()
+from demo.lightning.checkpoint.simulated.multiprocessing_train import BenchmarkStrategy, SimpleModel, format_size, get_tensor_size_bytes, split_tensor, cleanup, time_checkpoint_operation
 
 
 def configure_master_addr():
@@ -87,37 +46,6 @@ def init_processes() -> int:
     torch.distributed.init_process_group(
         backend='gloo', rank=rank, world_size=world_size)
     return rank
-
-
-def cleanup() -> None:
-    dist.destroy_process_group()
-
-
-def split_tensor(tensor: torch.Tensor, world_size: int, rank: int) -> torch.Tensor:
-    numel = tensor.numel()
-    split_size = numel // world_size
-    start_idx = rank * split_size
-    end_idx = start_idx + split_size if rank != world_size - 1 else numel
-    return tensor.view(-1)[start_idx:end_idx]
-
-
-def time_checkpoint_operation(benchmark_strategy: BenchmarkStrategy, distributed_state_dict: Dict[str, torch.Tensor], filepath: str, sample_size: int, operation: str) -> list:
-    times = []
-    for i in range(sample_size):
-        start_time = time.time()
-        if operation == 'save':
-            checkpoint_path = os.path.join(
-                filepath, f'checkpoints/ckpt_{i}.ckpt')
-            benchmark_strategy.save_checkpoint(
-                distributed_state_dict, filepath=checkpoint_path)
-        elif operation == 'load':
-            checkpoint_path = os.path.join(
-                filepath, f'checkpoints/ckpt_{i}.ckpt')
-            benchmark_strategy.load_checkpoint(checkpoint_path=checkpoint_path)
-        end_time = time.time()
-        times.append(end_time - start_time)
-        dist.barrier()  # Synchronize processes
-    return times
 
 
 def main(world_size: int, model_size: int, project: str, filepath: str, padding_size: int, sample_size: int) -> None:
@@ -165,6 +93,6 @@ if __name__ == "__main__":
     project = os.getenv("PROJECT")
     path = os.getenv("CKPT_DIR_PATH")
     sample_size = int(os.getenv("SAMPLE_SIZE", 3))
-    padding_size = int(os.getenv("PADDING_SIZE", 2000))
+    padding_size = int(os.getenv("PADDING_SIZE", 4000))
     main(world_size, model_size,
          project, path, padding_size, sample_size)

--- a/demo/lightning/checkpoint/simulated/multiprocessing_train.py
+++ b/demo/lightning/checkpoint/simulated/multiprocessing_train.py
@@ -1,17 +1,34 @@
+"""
+ Copyright 2024 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ """
 import argparse
+import os
+import time
+import statistics
+from typing import Optional, Dict
+
 import torch
 import torch.nn as nn
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.distributed.checkpoint as dist_cp
-import os
-import time
-
 from lightning.pytorch.strategies import FSDPStrategy
-
 from dataflux_pytorch.lightning.gcs_filesystem import GCSDistributedWriter, GCSDistributedReader
-import statistics
-from typing import Optional, Dict
+
+MASTER_ADDR = 'localhost'
+MASTER_PORT = '12355'
 
 
 class BenchmarkStrategy(FSDPStrategy):
@@ -43,40 +60,52 @@ class SimpleModel(nn.Module):
         return self.fc2(torch.relu(self.fc1(x)))
 
 
-def parse_args():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--project", type=str)
-    parser.add_argument("--ckpt-dir-path", type=str)
-    parser.add_argument("--model-size", type=int, default=100)
-    parser.add_argument("--clear-kernel-cache",
-                        action="store_true",
-                        default=False)
-    parser.add_argument("--sample-size", type=int, default=3)
-    parser.add_argument("--padding-size", type=int, default=1000)
-    parser.add_argument("--world-size", type=int)
+def parse_args() -> argparse.Namespace:
+    """Parses command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Benchmark distributed checkpointing.")
+    parser.add_argument("--project", type=str,
+                        required=True, help="GCS project ID.")
+    parser.add_argument("--ckpt-dir-path", type=str, required=True,
+                        help="Path to GCS bucket for checkpoints.")
+    parser.add_argument("--model-size", type=int,
+                        default=100, help="Size of the model.")
+    parser.add_argument("--clear-kernel-cache", action="store_true",
+                        default=False, help="Clear kernel cache.")
+    parser.add_argument("--sample-size", type=int, default=3,
+                        help="Number of samples for benchmarking.")
+    parser.add_argument("--padding-size", type=int, default=1000,
+                        help="Size of dummy tensors for padding, to control the size of the checkpoint.")
+    parser.add_argument("--world-size", type=int, required=True,
+                        help="Number of processes in the distributed setup.")
     return parser.parse_args()
 
 
 def format_size(size_bytes: int) -> str:
+    """Formats bytes into a human-readable size string."""
     size_mb = size_bytes / (1024 * 1024)
     return f"{size_mb / 1024:.2f} GB" if size_mb >= 1024 else f"{size_mb:.2f} MB"
 
 
 def get_tensor_size_bytes(tensor: torch.Tensor) -> int:
+    """Calculates the size of a tensor in bytes."""
     return tensor.element_size() * tensor.numel()
 
 
-def setup(rank, world_size):
-    os.environ['MASTER_ADDR'] = 'localhost'
-    os.environ['MASTER_PORT'] = '12355'
+def setup(rank: int, world_size: int) -> None:
+    """Sets up the distributed environment."""
+    os.environ['MASTER_ADDR'] = MASTER_ADDR
+    os.environ['MASTER_PORT'] = MASTER_PORT
     dist.init_process_group("gloo", rank=rank, world_size=world_size)
 
 
 def cleanup() -> None:
+    """Cleans up the distributed environment."""
     dist.destroy_process_group()
 
 
 def split_tensor(tensor: torch.Tensor, world_size: int, rank: int) -> torch.Tensor:
+    """Splits a tensor into chunks for distributed processing."""
     numel = tensor.numel()
     split_size = numel // world_size
     start_idx = rank * split_size
@@ -85,6 +114,7 @@ def split_tensor(tensor: torch.Tensor, world_size: int, rank: int) -> torch.Tens
 
 
 def time_checkpoint_operation(benchmark_strategy: BenchmarkStrategy, distributed_state_dict: Dict[str, torch.Tensor], filepath: str, sample_size: int, operation: str) -> list:
+    """Times save or load operations for checkpoints."""
     times = []
     for i in range(sample_size):
         start_time = time.time()
@@ -142,6 +172,15 @@ def run_benchmark(rank, world_size: int, model_size: int, project: str, filepath
 
 
 def main():
+    """
+    Typical usage example:
+
+      python3 -u demo/lightning/checkpoint/simulated/multiprocessing_train.py \
+      --project=<gcs_project_id> \
+      --ckpt-dir-path=<path_to_gcs_bucket> \
+      --model-size=300 \
+      --world-size=5
+    """
     args = parse_args()
 
     mp.set_start_method('spawn')
@@ -150,10 +189,4 @@ def main():
 
 
 if __name__ == "__main__":
-    # world_size = int(os.getenv("WORLD_SIZE"))
-    # model_size = int(os.getenv("NUM_LAYERS"))
-    # project = os.getenv("PROJECT")
-    # path = os.getenv("CKPT_DIR_PATH")
-    # sample_size = int(os.getenv("SAMPLE_SIZE", 3))
-    # padding_size = int(os.getenv("PADDING_SIZE", 2000))
     main()

--- a/demo/lightning/checkpoint/simulated/multiprocessing_train.py
+++ b/demo/lightning/checkpoint/simulated/multiprocessing_train.py
@@ -1,0 +1,159 @@
+import argparse
+import torch
+import torch.nn as nn
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.distributed.checkpoint as dist_cp
+import os
+import time
+
+from lightning.pytorch.strategies import FSDPStrategy
+
+from dataflux_pytorch.lightning.gcs_filesystem import GCSDistributedWriter, GCSDistributedReader
+import statistics
+from typing import Optional, Dict
+
+
+class BenchmarkStrategy(FSDPStrategy):
+    def __init__(self, project: str, path: str, model: nn.Module, **kwargs) -> None:
+        super().__init__(**kwargs)
+        self.writer = GCSDistributedWriter(path, project, None)
+        self.reader = GCSDistributedReader(path, project, None)
+        self.model = model
+
+    def save_checkpoint(self, checkpoint: Dict[str, torch.Tensor], filepath: str, storage_options: Optional[Dict] = None) -> None:
+        dist_cp.save(state_dict=checkpoint, checkpoint_id=filepath,
+                     storage_writer=self.writer)
+
+    def load_checkpoint(self, checkpoint_path: str) -> None:
+        empty_state_dict = {}
+        dist_cp.load(state_dict=empty_state_dict,
+                     checkpoint_id=checkpoint_path, storage_reader=self.reader)
+
+
+class SimpleModel(nn.Module):
+    def __init__(self, size: int, padding_size: int) -> None:
+        super(SimpleModel, self).__init__()
+        self.fc1 = nn.Linear(size, size)
+        self.fc2 = nn.Linear(size, size)
+        self.dummy_tensors = [torch.randn(size, size)
+                              for _ in range(padding_size)]
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.fc2(torch.relu(self.fc1(x)))
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--project", type=str)
+    parser.add_argument("--ckpt-dir-path", type=str)
+    parser.add_argument("--model-size", type=int, default=100)
+    parser.add_argument("--clear-kernel-cache",
+                        action="store_true",
+                        default=False)
+    parser.add_argument("--sample-size", type=int, default=3)
+    parser.add_argument("--padding-size", type=int, default=1000)
+    parser.add_argument("--world-size", type=int)
+    return parser.parse_args()
+
+
+def format_size(size_bytes: int) -> str:
+    size_mb = size_bytes / (1024 * 1024)
+    return f"{size_mb / 1024:.2f} GB" if size_mb >= 1024 else f"{size_mb:.2f} MB"
+
+
+def get_tensor_size_bytes(tensor: torch.Tensor) -> int:
+    return tensor.element_size() * tensor.numel()
+
+
+def setup(rank, world_size):
+    os.environ['MASTER_ADDR'] = 'localhost'
+    os.environ['MASTER_PORT'] = '12355'
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
+
+
+def cleanup() -> None:
+    dist.destroy_process_group()
+
+
+def split_tensor(tensor: torch.Tensor, world_size: int, rank: int) -> torch.Tensor:
+    numel = tensor.numel()
+    split_size = numel // world_size
+    start_idx = rank * split_size
+    end_idx = start_idx + split_size if rank != world_size - 1 else numel
+    return tensor.view(-1)[start_idx:end_idx]
+
+
+def time_checkpoint_operation(benchmark_strategy: BenchmarkStrategy, distributed_state_dict: Dict[str, torch.Tensor], filepath: str, sample_size: int, operation: str) -> list:
+    times = []
+    for i in range(sample_size):
+        start_time = time.time()
+        if operation == 'save':
+            checkpoint_path = os.path.join(
+                filepath, f'checkpoints/ckpt_{i}.ckpt')
+            benchmark_strategy.save_checkpoint(
+                distributed_state_dict, filepath=checkpoint_path)
+        elif operation == 'load':
+            checkpoint_path = os.path.join(
+                filepath, f'checkpoints/ckpt_{i}.ckpt')
+            benchmark_strategy.load_checkpoint(checkpoint_path=checkpoint_path)
+        end_time = time.time()
+        times.append(end_time - start_time)
+        dist.barrier()  # Synchronize processes
+    return times
+
+
+def run_benchmark(rank, world_size: int, model_size: int, project: str, filepath: str, padding_size: int, sample_size: int):
+    setup(rank, world_size)
+
+    model = SimpleModel(model_size, padding_size)
+
+    dummy_input = torch.randn(100, model_size)
+    _ = model(dummy_input)
+
+    full_state_dict = model.state_dict()
+    for i, tensor in enumerate(model.dummy_tensors):
+        full_state_dict[f'dummy_tensor_{i}'] = tensor
+
+    benchmark_strategy = BenchmarkStrategy(
+        project=project, path=filepath, model=model)
+
+    distributed_state_dict = {f"{key}_shard_{rank}": split_tensor(
+        tensor, world_size, rank) for key, tensor in full_state_dict.items()}
+
+    save_checkpoint_times = time_checkpoint_operation(
+        benchmark_strategy, distributed_state_dict, filepath, sample_size, 'save')
+    load_checkpoint_times = time_checkpoint_operation(
+        benchmark_strategy, distributed_state_dict, filepath, sample_size, 'load')
+
+    if rank == 0:
+        print("######################")
+        print(
+            f"Time taken to save checkpoint: {statistics.mean(save_checkpoint_times):.4f} seconds")
+        print(
+            f"Time taken to load checkpoint: {statistics.mean(load_checkpoint_times):.4f} seconds")
+        total_distributed_size_bytes = sum(get_tensor_size_bytes(
+            tensor) for tensor in distributed_state_dict.values())
+        print(
+            f"Size of distributed tensors (rank {rank}): {format_size(total_distributed_size_bytes)}")
+        print(
+            f"Total size of all tensors (rank {rank}): {format_size(total_distributed_size_bytes * world_size)}")
+        print("######################")
+
+
+def main():
+    args = parse_args()
+
+    mp.set_start_method('spawn')
+    mp.spawn(run_benchmark, args=(args.world_size, args.model_size, args.project, args.ckpt_dir_path, args.padding_size, args.sample_size),
+             nprocs=args.world_size, join=True)
+
+
+if __name__ == "__main__":
+    # world_size = int(os.getenv("WORLD_SIZE"))
+    # model_size = int(os.getenv("NUM_LAYERS"))
+    # project = os.getenv("PROJECT")
+    # path = os.getenv("CKPT_DIR_PATH")
+    # sample_size = int(os.getenv("SAMPLE_SIZE", 3))
+    # padding_size = int(os.getenv("PADDING_SIZE", 2000))
+    main()


### PR DESCRIPTION
This PR adds simulated benchmarking code for CPU, this version can be run directly on cloudtop as well as can be integrated into Kokoro runs (Hence it unblocks [b/361427435](https://b.corp.google.com/361427435) 

Also sharing code between demo & benchmarks so that there is no discrepancy between both the versions.  

- [X] Tests pass

<details>
<summary>Logs from sample run</summary>
```
(.venv) yashsha@yashsha1:~/vscode/dataflux-pytorch$ python3 -u demo/lightning/checkpoint/simulated/multiprocessing_train.py --project=gcs-tess, --ckpt-dir-path=gs://yashsha-us-east1-d/ --model-size=300 --world-size=5
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_0.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_0.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_0.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_0.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_0.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:116: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  if tensor.storage().size() != tensor.numel():
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:116: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  if tensor.storage().size() != tensor.numel():
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:116: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  if tensor.storage().size() != tensor.numel():
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:116: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  if tensor.storage().size() != tensor.numel():
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:116: UserWarning: TypedStorage is deprecated. It will be removed in the future and UntypedStorage will be the only storage class. This should only matter to you if you are using storages directly.  To access UntypedStorage directly, use tensor.untyped_storage() instead of tensor.storage()
  if tensor.storage().size() != tensor.numel():
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_1.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_1.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_1.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_1.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_1.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_2.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_2.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_2.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_2.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
/usr/local/google/home/yashsha/vscode/.venv/lib/python3.11/site-packages/torch/distributed/checkpoint/filesystem.py:490: UserWarning: Detected an existing checkpoint in gs:/yashsha-us-east1-d/checkpoints/ckpt_2.ckpt/.metadata, overwriting since self.overwrite=True. Past version 2.5 of PyTorch, `overwrite` will default to False. Set this variable to True to maintain this functionality or False to raise when an existing checkpoint is found.
  warnings.warn(
######################
Time taken to save checkpoint: 2.2351 seconds
Time taken to load checkpoint: 0.2796 seconds
Size of distributed tensors (rank 0): 68.80 MB
Total size of all tensors (rank 0): 344.01 MB
######################
```
</details>