### PR TITLE
Multi-node checkpoint benchmark improvements

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/multinode/README.md
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/README.md
@@ -27,6 +27,8 @@ You will need to set the following environment variables in order for the benchm
   
   * `CKPT_DIR_PATH`: The full path of the directory in which to save checkpoints, in the format `gs://<bucket>/<directory>/`
 
+  * `CKPT_RESTORE_PATH`: The path to restore checkpoints from. Typically the `CKPT_DIR_PATH` + `/checkpoints/`
+
 2. Set the optional environment variables, if desired:
   
   * `NUM_LAYERS`: The number of layers in the model, which affects the size of the model and therefore the size of the checkpoints. Defaults to 10.
@@ -46,6 +48,10 @@ You will need to set the following environment variables in order for the benchm
   
   * `MAX_STEPS_RESTORE`: Maximum number of steps for which training can run during second trainig loop. Defaults to 5. 
 
+  * `NUM_NODES`: The number of nodes (machines). Defaults to 1.
+
+  * `NUM_DEVICES`: The number of devices per node, or `auto`. Defaults to `auto`. 
+
 
 ### Installing Requirements:
  
@@ -63,5 +69,5 @@ You will need to set the following environment variables in order for the benchm
 To run the script use the following command. 
 
 ```shell
-python dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+python3 -m dataflux_pytorch.benchmark.checkpointing.multinode.train
 ```

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/benchmark-deploy.yaml
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/benchmark-deploy.yaml
@@ -65,7 +65,7 @@ spec:
                       fieldPath: metadata.annotations['batch.kubernetes.io/job-completion-index']
                 - name: PROCESSES_IN_JOB
                   value: "15"
-                - name: WORLD_SIZE
+                - name: NUM_NODES
                   value: "15"
 
                 - name: JOBSET_NAME

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -135,7 +135,8 @@ def main(project: str,
         )
         trainer.fit(model, dataloader)
         start = time.time()
-        trainer.strategy.load_checkpoint(new_path)
+        trainer._checkpoint_connector.restore(new_path)
+        # trainer.strategy.load_checkpoint(new_path)
         end = time.time()
 
         if torch.distributed.get_rank() == 0:

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -1,17 +1,19 @@
-from demo.lightning.checkpoint.multinode.fsspecfsdp import FSSpecFSDPStrategy
-from demo.lightning.checkpoint.multinode.train import DatafluxFSDPStrategy, init_processes, DemoTransformer
-
-import os
-import time
-import torch
-import statistics
 import argparse
+import os
+import statistics
+import time
 
+import torch
+import torch.distributed
 from lightning import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
-from lightning.pytorch.demos import (WikiText2)
-import torch.distributed
+from lightning.pytorch.demos import WikiText2
 from torch.utils.data import DataLoader
+
+from demo.lightning.checkpoint.multinode.fsspecfsdp import FSSpecFSDPStrategy
+from demo.lightning.checkpoint.multinode.train import (DatafluxFSDPStrategy,
+                                                       DemoTransformer,
+                                                       init_processes)
 
 DF_FSDP_STRATEGY = "dataflux_fsdp"
 FSSPEC_FSDP_STRATEGY = "fsspec_fsdp"
@@ -131,7 +133,7 @@ def main(project: str,
             devices=1,
             num_nodes=num_nodes,
         )
-        trainer.fit(model, dataloader, ckpt_path=new_path)
+        trainer.fit(model, dataloader)
         start = time.time()
         trainer.strategy.load_checkpoint(new_path)
         end = time.time()

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -68,7 +68,7 @@ def main(project: str,
     min_epochs_save = int(os.environ.get("MIN_EPOCHS_SAVE", 4))
     max_epochs_save = int(os.environ.get("MAX_EPOCHS_SAVE", 5))
     max_steps_save = int(os.environ.get("MAX_STEPS_SAVE", 3))
-    num_nodes = int(os.environ.get("WORLD_SIZE", 4))
+    num_nodes = int(os.environ.get("NUM_NODES", 1))
 
     trainer = Trainer(
         default_root_dir=ckpt_dir_path,

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -105,8 +105,7 @@ def main(project: str,
         )
         model = DemoTransformer(vocab_size=dataset.vocab_size,
                                 nlayers=int(os.environ.get("NUM_LAYERS", 10)))
-        new_path = ckpt_restore_path
-        # new_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
+        new_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
         strategy = None
         if args.strategy == DF_FSDP_STRATEGY:
             print("Using DatafluxFSDPStrategy")
@@ -123,7 +122,7 @@ def main(project: str,
                                           model=model,
                                           state_dict_type="sharded")
         trainer = Trainer(
-            default_root_dir=new_path,
+            default_root_dir=ckpt_dir_path,
             plugins=[],
             callbacks=[checkpoint_callback],
             min_epochs=min_epochs_restore,
@@ -136,7 +135,7 @@ def main(project: str,
         )
         trainer.fit(model, dataloader, ckpt_path=new_path)
         start = time.time()
-        # trainer.strategy.load_checkpoint(new_path)
+        trainer.strategy.load_checkpoint(new_path)
         end = time.time()
 
         if torch.distributed.get_rank() == 0:

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -105,7 +105,8 @@ def main(project: str,
         )
         model = DemoTransformer(vocab_size=dataset.vocab_size,
                                 nlayers=int(os.environ.get("NUM_LAYERS", 10)))
-        new_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
+        new_path = ckpt_restore_path
+        # new_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
         strategy = None
         if args.strategy == DF_FSDP_STRATEGY:
             print("Using DatafluxFSDPStrategy")
@@ -135,7 +136,8 @@ def main(project: str,
         )
         trainer.fit(model, dataloader)
         start = time.time()
-        trainer.strategy.load_checkpoint(new_path)
+        trainer._checkpoint_connector.restore(new_path)
+        # trainer.strategy.load_checkpoint(new_path)
         end = time.time()
 
         if torch.distributed.get_rank() == 0:

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -59,6 +59,7 @@ def main(project: str,
             storage_client=None,
             model=model,
             state_dict_type="sharded",
+            use_orig_params=False,
         )
     else:
         print("Using FSSpecFSDPStrategy")
@@ -115,6 +116,7 @@ def main(project: str,
                 storage_client=None,
                 model=model,
                 state_dict_type="sharded",
+                use_orig_params=False,
             )
         else:
             print("Using FSSpecFSDPStrategy")

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -81,7 +81,6 @@ def main(project: str,
         strategy=strategy,
         devices='auto',
         num_nodes=num_nodes,
-        profiler="advanced",
     )
     trainer.fit(model, dataloader)
     print(f"Saving checkpoint to {ckpt_dir_path} {max_steps_save} times.")
@@ -133,7 +132,6 @@ def main(project: str,
             strategy=strategy,
             devices='auto',
             num_nodes=num_nodes,
-            profiler="advanced",
         )
         trainer.fit(model, dataloader, ckpt_path=new_path)
         start = time.time()

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -81,6 +81,7 @@ def main(project: str,
         strategy=strategy,
         devices='auto',
         num_nodes=num_nodes,
+        profiler="advanced",
     )
     trainer.fit(model, dataloader)
     print(f"Saving checkpoint to {ckpt_dir_path} {max_steps_save} times.")
@@ -132,6 +133,7 @@ def main(project: str,
             strategy=strategy,
             devices='auto',
             num_nodes=num_nodes,
+            profiler="advanced",
         )
         trainer.fit(model, dataloader, ckpt_path=new_path)
         start = time.time()

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -79,7 +79,7 @@ def main(project: str,
         max_steps=max_steps_save,
         accelerator="gpu",
         strategy=strategy,
-        devices=1,
+        devices='auto',
         num_nodes=num_nodes,
     )
     trainer.fit(model, dataloader)
@@ -130,7 +130,7 @@ def main(project: str,
             max_steps=max_steps_restore,
             accelerator="gpu",
             strategy=strategy,
-            devices=1,
+            devices='auto',
             num_nodes=num_nodes,
         )
         trainer.fit(model, dataloader)

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -134,7 +134,7 @@ def main(project: str,
             devices='auto',
             num_nodes=num_nodes,
         )
-        trainer.fit(model, dataloader)
+        trainer.fit(model, dataloader, ckpt_path=new_path)
         start = time.time()
         # trainer.strategy.load_checkpoint(new_path)
         end = time.time()

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -123,7 +123,7 @@ def main(project: str,
                                           model=model,
                                           state_dict_type="sharded")
         trainer = Trainer(
-            default_root_dir=ckpt_dir_path,
+            default_root_dir=new_path,
             plugins=[],
             callbacks=[checkpoint_callback],
             min_epochs=min_epochs_restore,
@@ -136,7 +136,6 @@ def main(project: str,
         )
         trainer.fit(model, dataloader)
         start = time.time()
-        trainer._checkpoint_connector.restore(new_path)
         # trainer.strategy.load_checkpoint(new_path)
         end = time.time()
 

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -65,7 +65,8 @@ def main(project: str,
         print("Using FSSpecFSDPStrategy")
         strategy = FSSpecFSDPStrategy(path=ckpt_dir_path,
                                       model=model,
-                                      state_dict_type="sharded")
+                                      state_dict_type="sharded",
+                                      use_orig_params=False)
     min_epochs_save = int(os.environ.get("MIN_EPOCHS_SAVE", 4))
     max_epochs_save = int(os.environ.get("MAX_EPOCHS_SAVE", 5))
     max_steps_save = int(os.environ.get("MAX_STEPS_SAVE", 3))
@@ -80,7 +81,7 @@ def main(project: str,
         max_steps=max_steps_save,
         accelerator="gpu",
         strategy=strategy,
-        devices=os.environ.get("NUM_DEVICES", 1),
+        devices=os.environ.get("NUM_DEVICES", 'auto'),
         num_nodes=num_nodes,
     )
     trainer.fit(model, dataloader)
@@ -122,7 +123,8 @@ def main(project: str,
             print("Using FSSpecFSDPStrategy")
             strategy = FSSpecFSDPStrategy(path=new_path,
                                           model=model,
-                                          state_dict_type="sharded")
+                                          state_dict_type="sharded",
+                                          use_orig_params=False)
         trainer = Trainer(
             default_root_dir=ckpt_dir_path,
             plugins=[],
@@ -132,7 +134,7 @@ def main(project: str,
             max_steps=max_steps_restore,
             accelerator="gpu",
             strategy=strategy,
-            devices=os.environ.get("NUM_DEVICES", 1),
+            devices=os.environ.get("NUM_DEVICES", 'auto'),
             num_nodes=num_nodes,
         )
         trainer.fit(model, dataloader, ckpt_path=new_path)

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -79,7 +79,7 @@ def main(project: str,
         max_steps=max_steps_save,
         accelerator="gpu",
         strategy=strategy,
-        devices='auto',
+        devices=os.environ.get("NUM_DEVICES", 1),
         num_nodes=num_nodes,
     )
     trainer.fit(model, dataloader)
@@ -130,7 +130,7 @@ def main(project: str,
             max_steps=max_steps_restore,
             accelerator="gpu",
             strategy=strategy,
-            devices='auto',
+            devices=os.environ.get("NUM_DEVICES", 1),
             num_nodes=num_nodes,
         )
         trainer.fit(model, dataloader, ckpt_path=new_path)

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -135,8 +135,7 @@ def main(project: str,
         )
         trainer.fit(model, dataloader)
         start = time.time()
-        trainer._checkpoint_connector.restore(new_path)
-        # trainer.strategy.load_checkpoint(new_path)
+        trainer.strategy.load_checkpoint(new_path)
         end = time.time()
 
         if torch.distributed.get_rank() == 0:

--- a/dataflux_pytorch/lightning/gcs_filesystem.py
+++ b/dataflux_pytorch/lightning/gcs_filesystem.py
@@ -110,7 +110,6 @@ class GCSDistributedReader(FileSystemReader):
     def __init__(self,
                  path: Union[str, os.PathLike],
                  project_name: str,
-                 storage_client: Optional[storage.Client] = None,
-                 **kwargs):
-        super().__init__(path=path, **kwargs)
+                 storage_client: Optional[storage.Client] = None):
+        super().__init__(path=path)
         self.fs = GCSFileSystem(project_name, storage_client)

--- a/dataflux_pytorch/lightning/gcs_filesystem.py
+++ b/dataflux_pytorch/lightning/gcs_filesystem.py
@@ -6,7 +6,8 @@ from typing import Generator, Optional, Union, cast
 
 from dataflux_core import user_agent
 from google.cloud import storage
-from torch.distributed.checkpoint import FileSystemWriter, FileSystemReader
+from torch.distributed.checkpoint import FileSystemReader, FileSystemWriter
+
 from dataflux_pytorch.dataflux_checkpoint import DatafluxCheckpointBuffer
 from dataflux_pytorch.lightning.path_utils import parse_gcs_path
 
@@ -29,6 +30,7 @@ class GCSFileSystem():
                       mode: str) -> Generator[io.IOBase, None, None]:
         bucket, path = parse_gcs_path(path)
         blob = self.storage_client.bucket(bucket).blob(path)
+        print(f"Creating stream for bucket {bucket} path {path} mode {mode}")
         if mode == "wb":  # write mode.
             with DatafluxCheckpointBuffer(blob) as stream:
                 yield stream

--- a/dataflux_pytorch/lightning/gcs_filesystem.py
+++ b/dataflux_pytorch/lightning/gcs_filesystem.py
@@ -110,6 +110,7 @@ class GCSDistributedReader(FileSystemReader):
     def __init__(self,
                  path: Union[str, os.PathLike],
                  project_name: str,
-                 storage_client: Optional[storage.Client] = None):
-        super().__init__(path=path)
+                 storage_client: Optional[storage.Client] = None,
+                 **kwargs):
+        super().__init__(path=path, **kwargs)
         self.fs = GCSFileSystem(project_name, storage_client)

--- a/dataflux_pytorch/lightning/gcs_filesystem.py
+++ b/dataflux_pytorch/lightning/gcs_filesystem.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator, Optional, Union, cast
 
+import torch.distributed
 from dataflux_core import user_agent
 from google.cloud import storage
 from torch.distributed.checkpoint import FileSystemReader, FileSystemWriter
@@ -30,7 +31,9 @@ class GCSFileSystem():
                       mode: str) -> Generator[io.IOBase, None, None]:
         bucket, path = parse_gcs_path(path)
         blob = self.storage_client.bucket(bucket).blob(path)
-        print(f"Creating stream for bucket {bucket} path {path} mode {mode}")
+        print(
+            f"Creating stream for bucket {bucket} path {path} mode {mode} on rank {torch.distributed.get_rank()}"
+        )
         if mode == "wb":  # write mode.
             with DatafluxCheckpointBuffer(blob) as stream:
                 yield stream

--- a/dataflux_pytorch/lightning/gcs_filesystem.py
+++ b/dataflux_pytorch/lightning/gcs_filesystem.py
@@ -2,9 +2,8 @@ import io
 import os
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Optional, Union, cast
+from typing import Generator, Optional, Union
 
-import torch.distributed
 from dataflux_core import user_agent
 from google.cloud import storage
 from torch.distributed.checkpoint import FileSystemReader, FileSystemWriter
@@ -31,9 +30,6 @@ class GCSFileSystem():
                       mode: str) -> Generator[io.IOBase, None, None]:
         bucket, path = parse_gcs_path(path)
         blob = self.storage_client.bucket(bucket).blob(path)
-        print(
-            f"Creating stream for bucket {bucket} path {path} mode {mode} on rank {torch.distributed.get_rank()}"
-        )
         if mode == "wb":  # write mode.
             with DatafluxCheckpointBuffer(blob) as stream:
                 yield stream

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -7,6 +7,7 @@ from typing import Generator
 
 import torch
 import torch.distributed
+import torch.optim
 from dataflux_core import user_agent
 from google.cloud import storage
 from lightning import Trainer
@@ -265,6 +266,9 @@ class DemoTransformer(LightningTransformer):
     ) -> None:
         super().__init__()
         self.model = Transformer(vocab_size=vocab_size, nlayers=nlayers)
+
+    def configure_optimizers(self) -> torch.optim.Optimizer:
+        return torch.optim.SGD(self.trainer.model.parameters(), lr=0.1)
 
 
 if __name__ == "__main__":

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -34,7 +34,7 @@ class DatafluxFSDPStrategy(FSDPStrategy):
         self.writer = GCSDistributedWriter(path,
                                            project_name,
                                            storage_client,
-                                           single_file_per_rank=False,
+                                           single_file_per_rank=True,
                                            per_thread_copy_ahead=1000000000)
         self.reader = GCSDistributedReader(path, project_name, storage_client)
         self.checkpoint_io = DatafluxLightningCheckpoint(

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -232,15 +232,20 @@ class DemoTransformer(LightningTransformer):
         self,
         vocab_size: int = 33278,
         nlayers: int = 2,
+        optimizer: str = "sgd",
     ) -> None:
         super().__init__()
+        self.optimizer = optimizer
         self.model = Transformer(vocab_size=vocab_size, nlayers=nlayers)
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
         # Use self.trainer.model.parameters so that we can set
         # use_orig_params=False on the Strategy. Using AdamW also results in a
         # checkpoint size roughly 20% of used GPU memory.
-        return torch.optim.AdamW(self.trainer.model.parameters(), lr=0.1)
+        if self.optimizer == "adamw":
+            return torch.optim.AdamW(self.trainer.model.parameters(), lr=0.1)
+        else:
+            return torch.optim.SGD(self.trainer.model.parameters(), lr=0.1)
 
 
 if __name__ == "__main__":

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -268,7 +268,8 @@ class DemoTransformer(LightningTransformer):
         self.model = Transformer(vocab_size=vocab_size, nlayers=nlayers)
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
-        return torch.optim.SGD(self.trainer.model.parameters(), lr=0.1)
+        return torch.optim.AdamW(self.trainer.model.parameters(), lr=0.1)
+        #return torch.optim.SGD(self.trainer.model.parameters(), lr=0.1)
 
 
 if __name__ == "__main__":

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -31,11 +31,7 @@ class DatafluxFSDPStrategy(FSDPStrategy):
 
     def __init__(self, path, project_name, storage_client, model, **kwargs):
         super().__init__(**kwargs)
-        self.writer = GCSDistributedWriter(path,
-                                           project_name,
-                                           storage_client,
-                                           single_file_per_rank=True,
-                                           per_thread_copy_ahead=1000000000)
+        self.writer = GCSDistributedWriter(path, project_name, storage_client)
         self.reader = GCSDistributedReader(path, project_name, storage_client)
         self.checkpoint_io = DatafluxLightningCheckpoint(
             project_name, storage_client)

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -36,10 +36,7 @@ class DatafluxFSDPStrategy(FSDPStrategy):
                                            storage_client,
                                            single_file_per_rank=False,
                                            per_thread_copy_ahead=1000000000)
-        self.reader = GCSDistributedReader(path,
-                                           project_name,
-                                           storage_client,
-                                           single_file_per_rank=False)
+        self.reader = GCSDistributedReader(path, project_name, storage_client)
         self.checkpoint_io = DatafluxLightningCheckpoint(
             project_name, storage_client)
         self.model = model

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import Generator
 
 import torch
+import torch.distributed
 from dataflux_core import user_agent
 from google.cloud import storage
 from lightning import Trainer
@@ -93,7 +94,9 @@ class DatafluxFSDPStrategy(FSDPStrategy):
 
         with state_dict_ctx:
             module_state = {"model": self.model.state_dict()}
-            self.reader.path = path
+            print(
+                f"load_checkpoint path is {path}, reader path is {self.reader.path} on rank {torch.distributed.get_rank()}"
+            )
             load(module_state, self.reader)
             self.model.load_state_dict(
                 module_state["model"],

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -31,8 +31,15 @@ class DatafluxFSDPStrategy(FSDPStrategy):
 
     def __init__(self, path, project_name, storage_client, model, **kwargs):
         super().__init__(**kwargs)
-        self.writer = GCSDistributedWriter(path, project_name, storage_client)
-        self.reader = GCSDistributedReader(path, project_name, storage_client)
+        self.writer = GCSDistributedWriter(path,
+                                           project_name,
+                                           storage_client,
+                                           single_file_per_rank=False,
+                                           per_thread_copy_ahead=1000000000)
+        self.reader = GCSDistributedReader(path,
+                                           project_name,
+                                           storage_client,
+                                           single_file_per_rank=False)
         self.checkpoint_io = DatafluxLightningCheckpoint(
             project_name, storage_client)
         self.model = model

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from typing import Generator
 
 import torch
-import torch.distributed
 import torch.optim
 from dataflux_core import user_agent
 from google.cloud import storage


### PR DESCRIPTION
Several minor fixes/improvements for the multi-node checkpoint benchmark:

- Update the README with some missing instructions
- Run as a module rather than directly with Python so that imports work correctly
- Update `WORLD_SIZE` env var to `NUM_NODES` because PyTorch / PyTorch Lightning appear to use `WORLD_SIZE` for other purposes
- Set `use_orig_params=False` when creating the strategy, since this avoids the time-consuming step of flattening the optimizer state dict
  - This happened on each node, so I'm hopeful that this gives us a better trend for throughput when scaling the number of nodes
  - This also required updating the model's `configure_optimizers` to use `self.trainer.model.parameters` instead of `self.model.parameters` as in the default (see https://github.com/Lightning-AI/pytorch-lightning/issues/17515)
- Make `NUM_DEVICES` a configurable environment variable
- Add the ability to configure the strategy with AdamW or SGD optimizer. AdamW appears to result in larger checkpoint files that are about 20% of the GPU memory utilization

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR