### PR TITLE
Skip saving checkpoints during training

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/multinode/README.md
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/README.md
@@ -36,17 +36,9 @@ You will need to set the following environment variables in order for the benchm
   * `ACCELERATOR`: Set to `gpu` if running on a GPU, or `cpu` if running on a CPU (default)
     * If running on a GPU, you also must set `PJRT_DEVICE` to `CPU`.
   
-  * `MIN_EPOCHS_SAVE`: Minimum epochs for which training should run during first training loop which saves checkpoint. Defaults to 4. For detailed explaination of min_epochs see [here](https://lightning.ai/docs/pytorch/stable/common/trainer.html#min-epochs).
+  * `NUM_SAVE_CALLS`: The number of times `trainer.save_checkpoint` is called. Defaults to 3.
   
-  * `MIN_EPOCHS_RESTORE`: Minimum epochs for which training should run during second training loop which restores checkpoint. Defaults to 4.
-  
-  * `MAX_EPOCHS_SAVE` : Maximum epochs for which training should run during first training loop, which saves checkpoint. Defaults to 5. For detailed explanation of max_epochs see [here](https://lightning.ai/docs/pytorch/stable/common/trainer.html#max-epochs).
-  
-  * `MAX_EPOCHS_RESTORE` : Maximum epochs for which training should run during second training loop, which restores checkpoint. Defaults to 5.
-  
-  * `MAX_STEPS_SAVE`: Maximum number of steps for which training can run during first trainig loop. Defaults to 5. For more infomration on max_steps see [here](https://lightning.ai/docs/pytorch/stable/common/trainer.html#max-steps).
-  
-  * `MAX_STEPS_RESTORE`: Maximum number of steps for which training can run during second trainig loop. Defaults to 5. 
+  * `NUM_LOAD_CALLS`: The number of times `trainer.strategy.load_checkpoint` is called. Defaults to 3. 
 
   * `NUM_NODES`: The number of nodes (machines). Defaults to 1.
 

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -101,7 +101,8 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
         model = DemoTransformer(vocab_size=dataset.vocab_size,
                                 nlayers=int(os.environ.get("NUM_LAYERS", 10)))
         new_ckpt_dir_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
-        strategy = get_strategy(args.strategy, model, new_ckpt_dir_path)
+        strategy = get_strategy(args.strategy, os.getenv("PROJECT"), model,
+                                new_ckpt_dir_path)
         trainer = Trainer(
             enable_checkpointing=False,
             default_root_dir=ckpt_dir_path,

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -70,8 +70,6 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
     model = DemoTransformer(vocab_size=dataset.vocab_size,
                             nlayers=int(os.environ.get("NUM_LAYERS", 10)))
     strategy = get_strategy(args.strategy, model, ckpt_dir_path)
-    min_epochs_save = int(os.environ.get("MIN_EPOCHS_SAVE", 4))
-    max_epochs_save = int(os.environ.get("MAX_EPOCHS_SAVE", 5))
     max_steps_save = int(os.environ.get("MAX_STEPS_SAVE", 3))
     num_nodes = int(os.environ.get("NUM_NODES", 1))
 
@@ -79,9 +77,9 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
         enable_checkpointing=False,
         default_root_dir=ckpt_dir_path,
         plugins=[],
-        min_epochs=min_epochs_save,
-        max_epochs=max_epochs_save,
-        max_steps=max_steps_save,
+        min_epochs=1,
+        max_epochs=1,
+        max_steps=1,
         accelerator="gpu",
         strategy=strategy,
         devices=os.environ.get("NUM_DEVICES", 'auto'),
@@ -97,8 +95,6 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
     if torch.distributed.get_rank() == 0:
         print(f"Saved checkpoint to {ckpt_dir_path} {max_steps_save} times.")
     avg_save_time = (end - start) / max_steps_save
-    min_epochs_restore = int(os.environ.get("MIN_EPOCHS_RESTORE", 4))
-    max_epochs_restore = int(os.environ.get("MAX_EPOCHS_RESTORE", 5))
     max_steps_restore = int(os.environ.get("MAX_STEPS_RESTORE", 3))
     load_checkpoint_times = []
     for i in range(max_steps_restore):
@@ -110,9 +106,9 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
             enable_checkpointing=False,
             default_root_dir=ckpt_dir_path,
             plugins=[],
-            min_epochs=min_epochs_restore,
-            max_epochs=max_epochs_restore,
-            max_steps=max_steps_restore,
+            min_epochs=1,
+            max_epochs=1,
+            max_steps=1,
             accelerator="gpu",
             strategy=strategy,
             devices=os.environ.get("NUM_DEVICES", 'auto'),
@@ -138,7 +134,10 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
 
 
 if __name__ == "__main__":
+    start = time.time()
     main(
         os.getenv("CKPT_DIR_PATH"),
         os.getenv("CKPT_RESTORE_PATH"),
     )
+    end = time.time()
+    print(f"Benchmark took {end - start} seconds.")

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -31,8 +31,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def get_strategy(choice, model, ckpt_dir_path):
-    project = os.getenv("PROJECT")
+def get_strategy(choice, project, model, ckpt_dir_path):
     strategy = None
     if choice == DF_FSDP_STRATEGY:
         print("Using DatafluxFSDPStrategy")
@@ -69,7 +68,8 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
 
     model = DemoTransformer(vocab_size=dataset.vocab_size,
                             nlayers=int(os.environ.get("NUM_LAYERS", 10)))
-    strategy = get_strategy(args.strategy, model, ckpt_dir_path)
+    strategy = get_strategy(args.strategy, os.getenv("PROJECT"), model,
+                            ckpt_dir_path)
     num_save_calls = int(os.environ.get("NUM_SAVE_CALLS", 3))
     num_nodes = int(os.environ.get("NUM_NODES", 1))
 

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -8,6 +8,8 @@ import torch.distributed
 from lightning import Trainer
 from lightning.pytorch.callbacks import ModelCheckpoint
 from lightning.pytorch.demos import WikiText2
+from lightning.pytorch.strategies import FSDPStrategy
+import torch.distributed
 from torch.utils.data import DataLoader
 
 from demo.lightning.checkpoint.multinode.fsspecfsdp import FSSpecFSDPStrategy
@@ -17,14 +19,44 @@ from demo.lightning.checkpoint.multinode.train import (DatafluxFSDPStrategy,
 
 DF_FSDP_STRATEGY = "dataflux_fsdp"
 FSSPEC_FSDP_STRATEGY = "fsspec_fsdp"
+FSDP_STRATEGY = "fsdp"
 
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--strategy',
-                        choices=[DF_FSDP_STRATEGY, FSSPEC_FSDP_STRATEGY],
-                        default=DF_FSDP_STRATEGY)
+    parser.add_argument(
+        '--strategy',
+        choices=[DF_FSDP_STRATEGY, FSSPEC_FSDP_STRATEGY, FSDP_STRATEGY],
+        default=DF_FSDP_STRATEGY)
     return parser.parse_args()
+
+
+def get_strategy(choice, model, ckpt_dir_path):
+    project = os.getenv("PROJECT")
+    strategy = None
+    if choice == DF_FSDP_STRATEGY:
+        print("Using DatafluxFSDPStrategy")
+        strategy = DatafluxFSDPStrategy(
+            path=ckpt_dir_path,
+            project_name=project,
+            storage_client=None,
+            model=model,
+            state_dict_type="sharded",
+            use_orig_params=False,
+        )
+    elif choice == FSSPEC_FSDP_STRATEGY:
+        print("Using FSSpecFSDPStrategy")
+        strategy = FSSpecFSDPStrategy(path=ckpt_dir_path,
+                                      model=model,
+                                      state_dict_type="sharded",
+                                      use_orig_params=False)
+    elif choice == FSDP_STRATEGY:
+        print("Using FSDPStrategy.")
+        strategy = FSDPStrategy(state_dict_type="sharded",
+                                use_orig_params=False)
+    else:
+        raise ValueError("Invalid strategy.")
+    return strategy
 
 
 def main(project: str,
@@ -50,23 +82,7 @@ def main(project: str,
         enable_version_counter=True,
     )
 
-    strategy = None
-    if args.strategy == DF_FSDP_STRATEGY:
-        print("Using DatafluxFSDPStrategy")
-        strategy = DatafluxFSDPStrategy(
-            path=ckpt_dir_path,
-            project_name=project,
-            storage_client=None,
-            model=model,
-            state_dict_type="sharded",
-            use_orig_params=False,
-        )
-    else:
-        print("Using FSSpecFSDPStrategy")
-        strategy = FSSpecFSDPStrategy(path=ckpt_dir_path,
-                                      model=model,
-                                      state_dict_type="sharded",
-                                      use_orig_params=False)
+    strategy = get_strategy(args.strategy, model, ckpt_dir_path)
     min_epochs_save = int(os.environ.get("MIN_EPOCHS_SAVE", 4))
     max_epochs_save = int(os.environ.get("MAX_EPOCHS_SAVE", 5))
     max_steps_save = int(os.environ.get("MAX_STEPS_SAVE", 3))
@@ -107,24 +123,8 @@ def main(project: str,
         )
         model = DemoTransformer(vocab_size=dataset.vocab_size,
                                 nlayers=int(os.environ.get("NUM_LAYERS", 10)))
-        new_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
-        strategy = None
-        if args.strategy == DF_FSDP_STRATEGY:
-            print("Using DatafluxFSDPStrategy")
-            strategy = DatafluxFSDPStrategy(
-                path=new_path,
-                project_name=project,
-                storage_client=None,
-                model=model,
-                state_dict_type="sharded",
-                use_orig_params=False,
-            )
-        else:
-            print("Using FSSpecFSDPStrategy")
-            strategy = FSSpecFSDPStrategy(path=new_path,
-                                          model=model,
-                                          state_dict_type="sharded",
-                                          use_orig_params=False)
+        new_ckpt_dir_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
+        strategy = get_strategy(args.strategy, model, new_ckpt_dir_path)
         trainer = Trainer(
             default_root_dir=ckpt_dir_path,
             plugins=[],
@@ -137,13 +137,13 @@ def main(project: str,
             devices=os.environ.get("NUM_DEVICES", 'auto'),
             num_nodes=num_nodes,
         )
-        trainer.fit(model, dataloader, ckpt_path=new_path)
+        trainer.fit(model, dataloader, ckpt_path=new_ckpt_dir_path)
         start = time.time()
-        trainer.strategy.load_checkpoint(new_path)
+        trainer.strategy.load_checkpoint(new_ckpt_dir_path)
         end = time.time()
 
         if torch.distributed.get_rank() == 0:
-            print(f"Loaded checkpoint from {new_path}.")
+            print(f"Loaded checkpoint from {new_ckpt_dir_path}.")
         load_checkpoint_times.append(end - start)
 
     if torch.distributed.get_rank() == 0:

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -70,7 +70,7 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
     model = DemoTransformer(vocab_size=dataset.vocab_size,
                             nlayers=int(os.environ.get("NUM_LAYERS", 10)))
     strategy = get_strategy(args.strategy, model, ckpt_dir_path)
-    max_steps_save = int(os.environ.get("MAX_STEPS_SAVE", 3))
+    num_save_calls = int(os.environ.get("NUM_SAVE_CALLS", 3))
     num_nodes = int(os.environ.get("NUM_NODES", 1))
 
     trainer = Trainer(
@@ -86,18 +86,18 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
         num_nodes=num_nodes,
     )
     trainer.fit(model, dataloader)
-    print(f"Saving checkpoint to {ckpt_dir_path} {max_steps_save} times.")
+    print(f"Saving checkpoint to {ckpt_dir_path} {num_save_calls} times.")
     start = time.time()
-    for i in range(max_steps_save):
+    for i in range(num_save_calls):
         trainer.save_checkpoint(
             os.path.join(ckpt_dir_path, f'checkpoints/ckpt_{i}.ckpt/'))
     end = time.time()
     if torch.distributed.get_rank() == 0:
-        print(f"Saved checkpoint to {ckpt_dir_path} {max_steps_save} times.")
-    avg_save_time = (end - start) / max_steps_save
-    max_steps_restore = int(os.environ.get("MAX_STEPS_RESTORE", 3))
+        print(f"Saved checkpoint to {ckpt_dir_path} {num_save_calls} times.")
+    avg_save_time = (end - start) / num_save_calls
+    num_load_calls = int(os.environ.get("NUM_LOAD_CALLS", 3))
     load_checkpoint_times = []
-    for i in range(max_steps_restore):
+    for i in range(num_load_calls):
         model = DemoTransformer(vocab_size=dataset.vocab_size,
                                 nlayers=int(os.environ.get("NUM_LAYERS", 10)))
         new_ckpt_dir_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -152,8 +152,6 @@ def configure_master_addr():
 def init_processes():
     """Initializes the distributed environment."""
     # Get the necessary environment variables from the GKE environment.
-    world_size = int(os.environ["WORLD_SIZE"])
-
     job_index = int(os.environ.get("JOB_INDEX"))
     job_completion_index = int(os.environ.get("JOB_COMPLETION_INDEX"))
     processes_in_job = int(os.environ.get("PROCESSES_IN_JOB"))


### PR DESCRIPTION
Currently checkpoints are saved during `trainer.fit` which is not needed because we manually save checkpoints by calling `trainer.save_checkpoint`

- [X] Tests pass - ran locally on a VM with 4 GPUs and on a GKE cluster with 2 nodes
- [X] Appropriate changes to documentation are included in the PR - N/A