### PR TITLE
Install checkpoint benchmark dependencies before running the benchmark

### DIFF
--- a/kokoro/bench.sh
+++ b/kokoro/bench.sh
@@ -53,9 +53,6 @@ function install_requirements() {
     echo Installing image training demo requirements.
     pip install -r ./demo/lightning/image-segmentation/requirements.txt
 
-    echo Installing checkpointing demo requirements.
-    pip install -r ./dataflux_pytorch/benchmark/requirements.txt
-
     echo Installing required dependencies.
     pip install .
 }
@@ -66,6 +63,8 @@ function run_benchmarks(){
     python3 -u ./demo/lightning/text-based/distributed/model.py --local --project=dataflux-project --bucket=fineweb-df-benchmark --num-workers=2 --num-nodes=1 --devices=5 --batch-size=512 --epochs=5 --limit-train-batches=1000 --log-level=ERROR;
     echo Running image-segmentation benchmark.
     python3 -u ./demo/lightning/image-segmentation/train.py --local --benchmark --gcp_project=dataflux-project --gcs_bucket=dataflux-demo-public --images_prefix=image-segmentation-dataset/images --labels_prefix=image-segmentation-dataset/labels --num_nodes=1 --num_devices=5 --epochs=2;
+    echo Installing checkpointing demo requirements.
+    pip install -r ./dataflux_pytorch/benchmark/requirements.txt
     echo Running single node checkpointing benchmark.
     python3 -u ./dataflux_pytorch/benchmark/checkpointing/singlenode/train.py --project=dataflux-project --ckpt-dir-path=gs://df-ckpt-presubmit/ --layers=1000 --steps=5
     echo Running single node async checkpointing benchmark.


### PR DESCRIPTION
Resolves ongoing continuous benchmark failures