### PR TITLE
Add an option to benchmark only save calls

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -129,8 +129,8 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
             print(f"Loaded checkpoint from {new_ckpt_dir_path}.")
         load_checkpoint_times.append(end - start)
 
-    avg_load_time = statistics.mean(load_checkpoint_times)
     if torch.distributed.get_rank() == 0:
+        avg_load_time = statistics.mean(load_checkpoint_times)
         print("##################################")
         print("Average time to save one checkpoint: " + str(avg_save_time) +
               " seconds")

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -24,6 +24,7 @@ FSDP_STRATEGY = "fsdp"
 
 def parse_args():
     parser = argparse.ArgumentParser()
+    parser.add_argument("--save_only", action="store_true", default=False)
     parser.add_argument(
         '--strategy',
         choices=[DF_FSDP_STRATEGY, FSSPEC_FSDP_STRATEGY, FSDP_STRATEGY],
@@ -95,42 +96,46 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
     if torch.distributed.get_rank() == 0:
         print(f"Saved checkpoint to {ckpt_dir_path} {num_save_calls} times.")
     avg_save_time = (end - start) / num_save_calls
-    num_load_calls = int(os.environ.get("NUM_LOAD_CALLS", 3))
-    load_checkpoint_times = []
-    for i in range(num_load_calls):
-        model = DemoTransformer(vocab_size=dataset.vocab_size,
-                                nlayers=int(os.environ.get("NUM_LAYERS", 10)))
-        new_ckpt_dir_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
-        strategy = get_strategy(args.strategy, os.getenv("PROJECT"), model,
-                                new_ckpt_dir_path)
-        trainer = Trainer(
-            enable_checkpointing=False,
-            default_root_dir=ckpt_dir_path,
-            plugins=[],
-            min_epochs=1,
-            max_epochs=1,
-            max_steps=1,
-            accelerator="gpu",
-            strategy=strategy,
-            devices=os.environ.get("NUM_DEVICES", 'auto'),
-            num_nodes=num_nodes,
-        )
-        trainer.fit(model, dataloader, ckpt_path=new_ckpt_dir_path)
-        start = time.time()
-        trainer.strategy.load_checkpoint(new_ckpt_dir_path)
-        end = time.time()
+    if not args.save_only:
+        num_load_calls = int(os.environ.get("NUM_LOAD_CALLS", 3))
+        load_checkpoint_times = []
+        for i in range(num_load_calls):
+            model = DemoTransformer(vocab_size=dataset.vocab_size,
+                                    nlayers=int(
+                                        os.environ.get("NUM_LAYERS", 10)))
+            new_ckpt_dir_path = os.path.join(ckpt_restore_path,
+                                             f'ckpt_{i}.ckpt/')
+            strategy = get_strategy(args.strategy, os.getenv("PROJECT"), model,
+                                    new_ckpt_dir_path)
+            trainer = Trainer(
+                enable_checkpointing=False,
+                default_root_dir=ckpt_dir_path,
+                plugins=[],
+                min_epochs=1,
+                max_epochs=1,
+                max_steps=1,
+                accelerator="gpu",
+                strategy=strategy,
+                devices=os.environ.get("NUM_DEVICES", 'auto'),
+                num_nodes=num_nodes,
+            )
+            trainer.fit(model, dataloader, ckpt_path=new_ckpt_dir_path)
+            start = time.time()
+            trainer.strategy.load_checkpoint(new_ckpt_dir_path)
+            end = time.time()
 
-        if torch.distributed.get_rank() == 0:
-            print(f"Loaded checkpoint from {new_ckpt_dir_path}.")
-        load_checkpoint_times.append(end - start)
+            if torch.distributed.get_rank() == 0:
+                print(f"Loaded checkpoint from {new_ckpt_dir_path}.")
+            load_checkpoint_times.append(end - start)
 
     if torch.distributed.get_rank() == 0:
         avg_load_time = statistics.mean(load_checkpoint_times)
         print("##################################")
         print("Average time to save one checkpoint: " + str(avg_save_time) +
               " seconds")
-        print("Average time to load one checkpoint: " + str(avg_load_time) +
-              " seconds")
+        if not args.save_only:
+            print("Average time to load one checkpoint: " +
+                  str(avg_load_time) + " seconds")
         print("##################################")
 
 

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -129,11 +129,11 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
             load_checkpoint_times.append(end - start)
 
     if torch.distributed.get_rank() == 0:
-        avg_load_time = statistics.mean(load_checkpoint_times)
         print("##################################")
         print("Average time to save one checkpoint: " + str(avg_save_time) +
               " seconds")
         if not args.save_only:
+            avg_load_time = statistics.mean(load_checkpoint_times)
             print("Average time to load one checkpoint: " +
                   str(avg_load_time) + " seconds")
         print("##################################")

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -98,6 +98,10 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
     avg_save_time = (end - start) / num_save_calls
     num_load_calls = int(os.environ.get("NUM_LOAD_CALLS", 3))
     load_checkpoint_times = []
+    if args.save_only:
+        print("Skipping loads because you set --save_only")
+        num_load_calls = 0
+        load_checkpoint_times = [0]
     for i in range(num_load_calls):
         model = DemoTransformer(vocab_size=dataset.vocab_size,
                                 nlayers=int(os.environ.get("NUM_LAYERS", 10)))
@@ -125,14 +129,13 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
             print(f"Loaded checkpoint from {new_ckpt_dir_path}.")
         load_checkpoint_times.append(end - start)
 
+    avg_load_time = statistics.mean(load_checkpoint_times)
     if torch.distributed.get_rank() == 0:
         print("##################################")
         print("Average time to save one checkpoint: " + str(avg_save_time) +
               " seconds")
-        if not args.save_only:
-            avg_load_time = statistics.mean(load_checkpoint_times)
-            print("Average time to load one checkpoint: " +
-                  str(avg_load_time) + " seconds")
+        print("Average time to load one checkpoint: " + str(avg_load_time) +
+              " seconds")
         print("##################################")
 
 


### PR DESCRIPTION
Tested locally on a VM with 4 GPUs with and without `--save_only`. 