### PR TITLE
Add Multinode Async Save demo code

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -22,9 +22,10 @@ FSSPEC_FSDP_STRATEGY = "fsspec_fsdp"
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('--strategy',
-                        choices=[DF_FSDP_STRATEGY, FSSPEC_FSDP_STRATEGY],
-                        default=DF_FSDP_STRATEGY)
+    parser.add_argument(
+        '--strategy',
+        choices=[DF_FSDP_STRATEGY, ASYNC_DF_STRATEGY, FSSPEC_FSDP_STRATEGY],
+        default=DF_FSDP_STRATEGY)
     return parser.parse_args()
 
 

--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -65,6 +65,7 @@ def main(project: str,
             use_orig_params=False,
         )
     elif args.strategy == ASYNC_DF_STRATEGY:
+        print("Using AsyncDatafluxFSDPStrategy")
         strategy = AsyncDatafluxFSDPStrategy(
             path=ckpt_dir_path,
             project_name=project,

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -137,14 +137,9 @@ class AsyncDatafluxFSDPStrategy(DatafluxFSDPStrategy):
         super().__init__(path, project_name, storage_client, model, **kwargs)
         self.checkpoint_results = []
 
-        dist.init_process_group("cpu:gloo,cuda:nccl")
-
-        default_group = dist.group.WORLD
-        default_backend = dist.get_backend(default_group)
         default_ranks = list(range(dist.get_world_size()))
-
-        self.checkpoint_group = dist.new_group(default_ranks,
-                                               backend=default_backend)
+        self.checkpoint_group = dist.new_group(
+            default_ranks, backend=self.process_group_backend)
 
     def _save(self, state, path) -> None:
         result = async_save(state,

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -181,6 +181,7 @@ def configure_master_addr():
 def init_processes():
     """Initializes the distributed environment."""
     # Get the necessary environment variables from the GKE environment.
+    world_size = int(os.environ.get("WORLD_SIZE"))
     job_index = int(os.environ.get("JOB_INDEX"))
     job_completion_index = int(os.environ.get("JOB_COMPLETION_INDEX"))
     processes_in_job = int(os.environ.get("PROCESSES_IN_JOB"))

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Generator
 
 import torch
+import torch.distributed as dist
 import torch.optim
 from dataflux_core import user_agent
 from google.cloud import storage
@@ -181,9 +182,15 @@ def init_processes():
     job_completion_index = int(os.environ.get("JOB_COMPLETION_INDEX"))
     processes_in_job = int(os.environ.get("PROCESSES_IN_JOB"))
     rank = job_index * processes_in_job + job_completion_index
+    # TODO(awonak): remove debug
+    print(
+        f"INIT RANK: {job_index} * {job_completion_index} + {processes_in_job} = {rank}"
+    )
     os.environ["NODE_RANK"] = str(rank)
-
     configure_master_addr()
+    dist.init_process_group("cpu:gloo,cuda:ncc",
+                            rank=rank,
+                            world_size=world_size)
 
 
 def main(project: str,

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -193,9 +193,7 @@ def init_processes():
     )
     os.environ["NODE_RANK"] = str(rank)
     configure_master_addr()
-    dist.init_process_group("cpu:gloo,cuda:ncc",
-                            rank=rank,
-                            world_size=world_size)
+    dist.init_process_group("gloo", rank=rank, world_size=world_size)
 
 
 def main(project: str,


### PR DESCRIPTION
Add demo code for running PyTorch distributed async save checkpoints.

This PR addresses the PoC demo aspect. We do not currently have a non-trivial training workload to provide better insight into the performance improvement that a network-blocking async save would provide given how quickly training occurs with the current multinode demo.

Future improvements include adding a `finalize()` method to the `AsyncDatafluxFSDPStrategy` to 1) add a blocking wait to ensure all `async_save` futures have completed, and 2) check for any errors or timeouts from any of the `async_save` calls.

Internal issue: [b/369839708](http://b/369839708)

- [x] Tests pass
- [ ] Appropriate changes to documentation are included in the PR