### PR TITLE
Correct table header row

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesnâ
 ### Checkpointing
 Checkpoint benchmarks were taken on a single GCE `n2d-standard-48` node co-located with a storage bucket in the `us-west1` region. These results were the average of 10 runs. Checkpoints were tested on [PyTorch Lightning's Transformer demo model](https://github.com/Lightning-AI/pytorch-lightning/blob/master/src/lightning/pytorch/demos/transformer.py) ranging in size from 19.8M to 6.5B parameters (~76MB to ~24GB checkpoints). Checkpoints used PyTorch Lightning's default checkpoint format where a single checkpoint file is produced.
 
-#### Checkpoint Save
+### Checkpoint Save
 
 | Checkpoint Type | Model Parameters | Checkpoint File Size (MB) | Avg Checkpoint Save Time | Write Throughput (MB/s) |
 | --- | --- | --- | --- | --- |
@@ -335,7 +335,7 @@ Checkpoint benchmarks were taken on a single GCE `n2d-standard-48` node co-locat
 | Dataflux         | 6.5 B  | 24,200| 64.50   | 375.19  |
 
 
-#### Checkpoint Load
+### Checkpoint Load
 
 | Checkpoint Type | Model Parameters | Checkpoint File Size (MB) | Avg Checkpoint Restore Time | Read Throughput (MB/s) |
 | --- | --- | --- | --- | --- |

--- a/README.md
+++ b/README.md
@@ -325,28 +325,28 @@ Checkpoint benchmarks were taken on a single GCE `n2d-standard-48` node co-locat
 
 | Checkpoint Type | Model Parameters | Checkpoint File Size (MB) | Avg Checkpoint Save Time | Write Throughput (MB/s) |
 | --- | --- | --- | --- | --- |
-| Without Dataflux | 75.6    | 19.8M | 0.81    | 93.33   |
-| Dataflux         | 75.6    | 19.8M | 0.56    | 135.00  |
-| Without Dataflux | 298     | 77.9M | 2.87    | 103.98  |
-| Dataflux         | 298     | 77.9M | 1.03    | 289.32  |
-| Without Dataflux | 2,500   | 658M | 25.61   | 97.61   |
-| Dataflux         | 2,500   | 658M | 6.25    | 400.00  |
-| Without Dataflux | 24,200  | 6.5B | 757.10  | 31.96   |
-| Dataflux         | 24,200  | 6.5B | 64.50   | 375.19  |
+| Without Dataflux | 19.8M  | 75.6  | 0.81    | 93.33   |
+| Dataflux         | 19.8M  | 75.6  | 0.56    | 135.00  |
+| Without Dataflux | 77.9 M | 298   | 2.87    | 103.98  |
+| Dataflux         | 77.9 M | 298   | 1.03    | 289.32  |
+| Without Dataflux | 658 M  | 2,500 | 25.61   | 97.61   |
+| Dataflux         | 658 M  | 2,500 | 6.25    | 400.00  |
+| Without Dataflux | 6.5 B  | 24,200| 757.10  | 31.96   |
+| Dataflux         | 6.5 B  | 24,200| 64.50   | 375.19  |
 
 
 ## Checkpoint Load
 
 | Checkpoint Type | Model Parameters | Checkpoint File Size (MB) | Avg Checkpoint Restore Time | Read Throughput (MB/s) |
 | --- | --- | --- | --- | --- |
-| Without Dataflux   | 75.6    | 19.8M | 2.38      | 31.76   |
-| Dataflux           | 75.6    | 19.8M | 0.51      | 148.24  |
-| Without Dataflux   | 298     | 77.9M | 1.69      | 176.33  |
-| Dataflux           | 298     | 77.9M | 1.03      | 289.32  |
-| Without Dataflux   | 2,500   | 658M | 186.57    | 13.40   |
-| Dataflux           | 2,500   | 658M | 14.77     | 169.26  |
-| Without Dataflux   | 24,200  | 6.5B | 2,093.52  | 11.56   |
-| Dataflux           | 24,200  | 6.5B | 113.14    | 213.89  |
+| Without Dataflux   | 19.8M  | 75.6  | 2.38      | 31.76   |
+| Dataflux           | 19.8M  | 75.6  | 0.51      | 148.24  |
+| Without Dataflux   | 77.9 M | 298   | 1.69      | 176.33  |
+| Dataflux           | 77.9 M | 298   | 1.03      | 289.32  |
+| Without Dataflux   | 658 M  | 2,500 | 186.57    | 13.40   |
+| Dataflux           | 658 M  | 2,500 | 14.77     | 169.26  |
+| Without Dataflux   | 6.5 B  | 24,200| 2,093.52  | 11.56   |
+| Dataflux           | 6.5 B  | 24,200| 113.14    | 213.89  |
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ Since the [DLIO benchmark](https://github.com/argonne-lcf/dlio_benchmark) doesnâ
 ### Checkpointing
 Checkpoint benchmarks were taken on a single GCE `n2d-standard-48` node co-located with a storage bucket in the `us-west1` region. These results were the average of 10 runs. Checkpoints were tested on [PyTorch Lightning's Transformer demo model](https://github.com/Lightning-AI/pytorch-lightning/blob/master/src/lightning/pytorch/demos/transformer.py) ranging in size from 19.8M to 6.5B parameters (~76MB to ~24GB checkpoints). Checkpoints used PyTorch Lightning's default checkpoint format where a single checkpoint file is produced.
 
-## Checkpoint Save
+#### Checkpoint Save
 
 | Checkpoint Type | Model Parameters | Checkpoint File Size (MB) | Avg Checkpoint Save Time | Write Throughput (MB/s) |
 | --- | --- | --- | --- | --- |
@@ -335,7 +335,7 @@ Checkpoint benchmarks were taken on a single GCE `n2d-standard-48` node co-locat
 | Dataflux         | 6.5 B  | 24,200| 64.50   | 375.19  |
 
 
-## Checkpoint Load
+#### Checkpoint Load
 
 | Checkpoint Type | Model Parameters | Checkpoint File Size (MB) | Avg Checkpoint Restore Time | Read Throughput (MB/s) |
 | --- | --- | --- | --- | --- |


### PR DESCRIPTION


- [x] Tests pass - n/a
- [x] Appropriate changes to documentation are included in the PR