### PR TITLE
delete and reconstruct client

### DIFF
--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -257,7 +257,6 @@ class DataFluxMapStyleDataset(data.Dataset):
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
         del state['storage_client']
-        print("get_state: client deleted")
         return state
 
     def __setstate__(self, state):
@@ -266,4 +265,3 @@ class DataFluxMapStyleDataset(data.Dataset):
         # Restore the previously opened file's state. To do so, we need to
         # reopen it and read from it until the line count is restored.
         self.storage_client = self._unpickle_client()
-        print("set_state: client created")

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -138,6 +138,9 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.bucket_name = bucket_name
         self.data_format_fn = data_format_fn
         self.config = config
+        if self.storage_client is None:
+            self.storage_client = storage.Client(project=self.project_name)
+        self._pickle_client()
         # If composed download is enabled and a storage_client was provided,
         # check if the client has permissions to create and delete the
         # composed object.
@@ -165,7 +168,7 @@ class DataFluxMapStyleDataset(data.Dataset):
     def __getitem__(self, idx):
         return self.data_format_fn(
             dataflux_core.download.download_single(
-                storage_client=self._get_or_create_storage_client(),
+                storage_client=self.storage_client,
                 bucket_name=self.bucket_name,
                 object_name=self.objects[idx][0],
                 retry_config=self.config.download_retry_config,
@@ -178,7 +181,7 @@ class DataFluxMapStyleDataset(data.Dataset):
                 project_name=self.project_name,
                 bucket_name=self.bucket_name,
                 objects=[self.objects[idx] for idx in indices],
-                storage_client=self._get_or_create_storage_client(),
+                storage_client=self.storage_client,
                 dataflux_download_optimization_params=self.
                 dataflux_download_optimization_params,
                 threads=self.config.threads_per_process,
@@ -201,8 +204,8 @@ class DataFluxMapStyleDataset(data.Dataset):
                     retry_config=self.config.list_retry_config,
                 )
                 # If the dataset was not initialized with an storage_client, ensure that we do not attach a client to the lister to avoid pickling errors (#58).
-                if self.storage_client is not None:
-                    lister.client = self.storage_client
+                # if self.storage_client is not None:
+                #     lister.client = self.storage_client
                 listed_objects = lister.run()
 
             except Exception as e:
@@ -232,3 +235,35 @@ class DataFluxMapStyleDataset(data.Dataset):
         if self.storage_client is not None:
             return self.storage_client
         return storage.Client(project=self.project_name)
+
+    def _pickle_client(self):
+        self.project = self.storage_client.project
+        self.credentials = self.storage_client._credentials
+        self.client_info = self.storage_client._initial_client_info
+        self.client_options = self.storage_client._initial_client_options
+        self.extra_headers = self.storage_client._extra_headers
+
+    def _unpickle_client(self):
+        return storage.Client(project=self.project,
+                              credentials=self.credentials,
+                              client_info=self.client_info,
+                              client_options=self.client_options,
+                              extra_headers=self.extra_headers)
+
+    def __getstate__(self):
+        # Copy the object's state from self.__dict__ which contains
+        # all our instance attributes. Always use the dict.copy()
+        # method to avoid modifying the original state.
+        state = self.__dict__.copy()
+        # Remove the unpicklable entries.
+        del state['storage_client']
+        print("get_state: client deleted")
+        return state
+
+    def __setstate__(self, state):
+        # Restore instance attributes (i.e., filename and lineno).
+        self.__dict__.update(state)
+        # Restore the previously opened file's state. To do so, we need to
+        # reopen it and read from it until the line count is restored.
+        self.storage_client = self._unpickle_client()
+        print("set_state: client created")

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -237,6 +237,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         return storage.Client(project=self.project_name)
 
     def _pickle_client(self):
+        """Reduce a Client by saving the intial params."""
         self.project = self.storage_client.project
         self.credentials = self.storage_client._credentials
         self.client_info = self.storage_client._initial_client_info
@@ -244,6 +245,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.extra_headers = self.storage_client._extra_headers
 
     def _unpickle_client(self):
+        """Replicate a Client by constructing a new one with the initial params."""
         return storage.Client(project=self.project,
                               credentials=self.credentials,
                               client_info=self.client_info,
@@ -252,7 +254,7 @@ class DataFluxMapStyleDataset(data.Dataset):
 
     def __getstate__(self):
         # Copy the object's state from self.__dict__ which contains
-        # all our instance attributes. Always use the dict.copy()
+        # all our instance attributes. Use the dict.copy()
         # method to avoid modifying the original state.
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
@@ -260,8 +262,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         return state
 
     def __setstate__(self, state):
-        # Restore instance attributes (i.e., filename and lineno).
+        # Restore instance attributes.
         self.__dict__.update(state)
-        # Restore the previously opened file's state. To do so, we need to
-        # reopen it and read from it until the line count is restored.
+        # Restore the storage client with initial params.
         self.storage_client = self._unpickle_client()


### PR DESCRIPTION
When multiprocess is called, client will be deleted and recreated for each process . This will resolve the pickling error when a client is passed by a user for Mac and Windows OS. Along with this a client will not be constructed every time.  Reduce storage client information and reconstruct the client using this information.

referred: https://docs.python.org/3/library/pickle.html#handling-stateful-objects

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR