### PR TITLE
move client initialization to getitem and getitems

### DIFF
--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -257,7 +257,6 @@ class DataFluxMapStyleDataset(data.Dataset):
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
         del state['storage_client']
-        print("get_state: client deleted")
         return state
 
     def __setstate__(self, state):
@@ -266,4 +265,3 @@ class DataFluxMapStyleDataset(data.Dataset):
         # Restore the previously opened file's state. To do so, we need to
         # reopen it and read from it until the line count is restored.
         self.storage_client = self._unpickle_client()
-        print("set_state: client created")

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -203,8 +203,8 @@ class DataFluxMapStyleDataset(data.Dataset):
                     retry_config=self.config.list_retry_config,
                 )
                 # If the dataset was not initialized with an storage_client, ensure that we do not attach a client to the lister to avoid pickling errors (#58).
-                if self.storage_client is not None:
-                    lister.client = self.storage_client
+                # if self.storage_client is not None:
+                #     lister.client = self.storage_client
                 listed_objects = lister.run()
 
             except Exception as e:

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -138,6 +138,9 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.bucket_name = bucket_name
         self.data_format_fn = data_format_fn
         self.config = config
+        if self.storage_client is None:
+            self.storage_client = storage.Client(project=self.project_name)
+        self._pickle_client()
         # If composed download is enabled and a storage_client was provided,
         # check if the client has permissions to create and delete the
         # composed object.
@@ -165,7 +168,7 @@ class DataFluxMapStyleDataset(data.Dataset):
     def __getitem__(self, idx):
         return self.data_format_fn(
             dataflux_core.download.download_single(
-                storage_client=self._get_or_create_storage_client(),
+                storage_client=self.storage_client,
                 bucket_name=self.bucket_name,
                 object_name=self.objects[idx][0],
                 retry_config=self.config.download_retry_config,
@@ -178,7 +181,7 @@ class DataFluxMapStyleDataset(data.Dataset):
                 project_name=self.project_name,
                 bucket_name=self.bucket_name,
                 objects=[self.objects[idx] for idx in indices],
-                storage_client=self._get_or_create_storage_client(),
+                storage_client=self.storage_client,
                 dataflux_download_optimization_params=self.
                 dataflux_download_optimization_params,
                 threads=self.config.threads_per_process,
@@ -201,8 +204,8 @@ class DataFluxMapStyleDataset(data.Dataset):
                     retry_config=self.config.list_retry_config,
                 )
                 # If the dataset was not initialized with an storage_client, ensure that we do not attach a client to the lister to avoid pickling errors (#58).
-                if self.storage_client is not None:
-                    lister.client = self.storage_client
+                # if self.storage_client is not None:
+                #     lister.client = self.storage_client
                 listed_objects = lister.run()
 
             except Exception as e:
@@ -232,3 +235,35 @@ class DataFluxMapStyleDataset(data.Dataset):
         if self.storage_client is not None:
             return self.storage_client
         return storage.Client(project=self.project_name)
+
+    def _pickle_client(self):
+        self.project = self.storage_client.project
+        self.credentials = self.storage_client._credentials
+        self.client_info = self.storage_client._initial_client_info
+        self.client_options = self.storage_client._initial_client_options
+        self.extra_headers = self.storage_client._extra_headers
+
+    def _unpickle_client(self):
+        return storage.Client(project=self.project,
+                              credentials=self.credentials,
+                              client_info=self.client_info,
+                              client_options=self.client_options,
+                              extra_headers=self.extra_headers)
+
+    def __getstate__(self):
+        # Copy the object's state from self.__dict__ which contains
+        # all our instance attributes. Always use the dict.copy()
+        # method to avoid modifying the original state.
+        state = self.__dict__.copy()
+        # Remove the unpicklable entries.
+        del state['storage_client']
+        print("get_state: client deleted")
+        return state
+
+    def __setstate__(self, state):
+        # Restore instance attributes (i.e., filename and lineno).
+        self.__dict__.update(state)
+        # Restore the previously opened file's state. To do so, we need to
+        # reopen it and read from it until the line count is restored.
+        self.storage_client = self._unpickle_client()
+        print("set_state: client created")

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -247,5 +247,5 @@ class DataFluxMapStyleDataset(data.Dataset):
     def __setstate__(self, state):
         # Restore instance attributes.
         self.__dict__.update(state)
-        # Restore the storage client with initial params.
+        # Create the storage client.
         self.storage_client = storage.Client(project=self.project_name)

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -203,8 +203,6 @@ class DataFluxMapStyleDataset(data.Dataset):
                     retry_config=self.config.list_retry_config,
                 )
                 # If the dataset was not initialized with an storage_client, ensure that we do not attach a client to the lister to avoid pickling errors (#58).
-                # if self.storage_client is not None:
-                #     lister.client = self.storage_client
                 listed_objects = lister.run()
 
             except Exception as e:

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -223,18 +223,6 @@ class DataFluxMapStyleDataset(data.Dataset):
         else:
             raise error
 
-    def _get_or_create_storage_client(self):
-        """Provide initialized storage client or construct one.
-
-        Some environments do not support pickling client objects, so
-        storage_client is an optional parameter. If the dataset was
-        initialized without a storage client, construct and provide one for
-        use.
-        """
-        if self.storage_client is not None:
-            return self.storage_client
-        return storage.Client(project=self.project_name)
-
     def __getstate__(self):
         # Copy the object's state from self.__dict__ which contains
         # all our instance attributes. Use the dict.copy()

--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -237,6 +237,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         return storage.Client(project=self.project_name)
 
     def _pickle_client(self):
+        """Reduce a Client by saving the intial params."""
         self.project = self.storage_client.project
         self.credentials = self.storage_client._credentials
         self.client_info = self.storage_client._initial_client_info
@@ -244,6 +245,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.extra_headers = self.storage_client._extra_headers
 
     def _unpickle_client(self):
+        """Replicate a Client by constructing a new one with the initial params."""
         return storage.Client(project=self.project,
                               credentials=self.credentials,
                               client_info=self.client_info,
@@ -252,7 +254,7 @@ class DataFluxMapStyleDataset(data.Dataset):
 
     def __getstate__(self):
         # Copy the object's state from self.__dict__ which contains
-        # all our instance attributes. Always use the dict.copy()
+        # all our instance attributes. Use the dict.copy()
         # method to avoid modifying the original state.
         state = self.__dict__.copy()
         # Remove the unpicklable entries.
@@ -260,8 +262,7 @@ class DataFluxMapStyleDataset(data.Dataset):
         return state
 
     def __setstate__(self, state):
-        # Restore instance attributes (i.e., filename and lineno).
+        # Restore instance attributes.
         self.__dict__.update(state)
-        # Restore the previously opened file's state. To do so, we need to
-        # reopen it and read from it until the line count is restored.
+        # Restore the storage client with initial params.
         self.storage_client = self._unpickle_client()

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -451,9 +451,11 @@ class ListingTestCase(unittest.TestCase):
             storage_client=self.storage_client,
         )
 
-        states = ds.__getstate__()
-        want_state = ds.__dict__
+        want_state = ds.__dict__.copy()
         want_state.pop("storage_client")
+
+        states = ds.__getstate__()
+
         # Assert.
         self.assertEqual(
             states,
@@ -470,7 +472,6 @@ class ListingTestCase(unittest.TestCase):
         mock_dataflux_core.fast_list.ListingController.return_value = (
             mock_listing_controller)
 
-        # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
             project_name=self.project_name,
             bucket_name=self.bucket_name,
@@ -478,12 +479,15 @@ class ListingTestCase(unittest.TestCase):
             storage_client=self.storage_client,
         )
 
+        # Remove storage_client from dataflux_mapstyle_dataset instance.
         ds.__dict__.pop("storage_client")
         self.assertNotIn(
             "storage_client", ds.__dict__,
-            f"Key 'storage_client' should not exist in dataflux_mapstyle_dataset instance"
+            f"Key 'storage_client' should was not removed from dataflux_mapstyle_dataset instance"
         )
         state = ds.__dict__.copy()
+
+        # Act.
         ds.__setstate__(state)
 
         # Assert.

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -477,14 +477,20 @@ class ListingTestCase(unittest.TestCase):
             config=self.config,
             storage_client=self.storage_client,
         )
-        want_state = ds.__dict__
+
         ds.__dict__.pop("storage_client")
-        ds.__setstate__()
+        self.assertNotIn(
+            "storage_client", ds.__dict__,
+            f"Key 'storage_client' should not exist in dataflux_mapstyle_dataset instance"
+        )
+        state = ds.__dict__.copy()
+        ds.__setstate__(state)
+
         # Assert.
-        self.assertEqual(
+        self.assertIn(
+            "storage_client",
             ds.__dict__,
-            want_state,
-            f"got dataflux_mapstyle_dataset params {ds.__dict__}, want {want_state}",
+            f"Key 'storage_client' should exist in dataflux_mapstyle_dataset instance",
         )
 
 

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -486,9 +486,9 @@ class ListingTestCase(unittest.TestCase):
         ds.__setstate__(state)
 
         # Assert.
-        self.assertIn(
-            "storage_client",
-            ds.__dict__,
+        self.assertIsInstance(
+            ds.__dict__['storage_client'],
+            storage.Client,
             f"Key 'storage_client' should exist in dataflux_mapstyle_dataset instance",
         )
 

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -48,14 +48,19 @@ class ListingTestCase(unittest.TestCase):
         ], self.bucket_name)
         self.storage_client = client
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
-    def test_init(self, mock_dataflux_core):
-        """Tests the DataFluxMapStyleDataset can be initiated with the expected listing results."""
-        # Arrange.
+    def initializeMockFastList(self, mock_dataflux_core):
+        """ Test helper function to """
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        mock_dataflux_core.return_value = (mock_listing_controller)
+
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
+    def test_init(self, mock_dataflux_core):
+        """Tests the DataFluxMapStyleDataset can be initiated with the expected listing results."""
+        # Setup mocks for testing.
+        self.initializeMockFastList(mock_dataflux_core)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -73,14 +78,13 @@ class ListingTestCase(unittest.TestCase):
             f"got listed objects {ds.objects}, want {self.want_objects}",
         )
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
     def test_init_with_required_parameters(self, mock_dataflux_core):
         """Tests the DataFluxMapStyleDataset can be initiated with only the required parameters."""
-        # Arrange.
-        mock_listing_controller = mock.Mock()
-        mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        # Setup mocks for testing.
+        self.initializeMockFastList(mock_dataflux_core)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -98,14 +102,13 @@ class ListingTestCase(unittest.TestCase):
             f"got listed objects {ds.objects}, want {self.want_objects}",
         )
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
     def test_init_without_storage_client(self, mock_dataflux_core):
         """Tests the DataFluxMapStyleDataset can be initiated without storage_client."""
-        # Arrange.
-        mock_listing_controller = mock.Mock()
-        mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        # Setup mocks for testing.
+        self.initializeMockFastList(mock_dataflux_core)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -126,7 +129,7 @@ class ListingTestCase(unittest.TestCase):
     def test_init_without_storage_client_constructed_when_needed(
             self, mock_dataflux_core):
         """Tests the DataFluxMapStyleDataset can be initiated without storage_client."""
-        # Arrange.
+        # Setup mocks for testing.
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
@@ -157,7 +160,7 @@ class ListingTestCase(unittest.TestCase):
     @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
     def test_init_retry_exception_passes(self, mock_dataflux_core):
         """Tests that the initialization retries objects llisting upon exception and passes."""
-        # Arrange.
+        # Setup mocks for testing.
         mock_listing_controller = mock.Mock()
 
         # Simulate that the first invocation raises an exception and the second invocation
@@ -190,7 +193,7 @@ class ListingTestCase(unittest.TestCase):
     def test_init_raises_exception_when_retries_exhaust(
             self, mock_dataflux_core):
         """Tests that the initialization raises exception upon exhaustive retries."""
-        # Arrange.
+        # Setup mocks for testing.
         mock_listing_controller = mock.Mock()
         want_exception = RuntimeError("123")
 
@@ -221,14 +224,13 @@ class ListingTestCase(unittest.TestCase):
             f"got exception {re.exception}, want {want_exception}",
         )
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
     def test_len(self, mock_dataflux_core):
         """Tests that the len(dataset) method returns the correct number of listed objects."""
-        # Arrange.
-        mock_listing_controller = mock.Mock()
-        mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        # Setup mocks for testing.
+        self.initializeMockFastList(mock_dataflux_core)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -249,7 +251,7 @@ class ListingTestCase(unittest.TestCase):
     @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
     def test_getitem(self, mock_dataflux_core):
         """Tests that the dataset[idx] method returns the correct downloaded object content."""
-        # Arrange.
+        # Setup mocks for testing.
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = sorted(self.want_objects)
         mock_dataflux_core.fast_list.ListingController.return_value = (
@@ -283,7 +285,7 @@ class ListingTestCase(unittest.TestCase):
     @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
     def test_getitems(self, mock_dataflux_core):
         """Tests that the dataset.__getitems__ method returns the list of the correct downloaded object content."""
-        # Arrange.
+        # Setup mocks for testing.
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.fast_list.ListingController.return_value = (
@@ -332,13 +334,12 @@ class ListingTestCase(unittest.TestCase):
             retry_config=dataflux_mapstyle_dataset.MODIFIED_RETRY,
         )
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
     def test_init_sets_user_agent(self, mock_dataflux_core):
         """Tests that the init function sets the storage client's user agent."""
-        mock_listing_controller = mock.Mock()
-        mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        self.initializeMockFastList(mock_dataflux_core)
 
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
             project_name=self.project_name,
@@ -354,16 +355,17 @@ class ListingTestCase(unittest.TestCase):
             f"got listed objects {ds.objects}, want {self.want_objects}",
         )
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
     def test_list_GCS_blobs_with_spawn_multiprocess(self, mock_dataflux_core):
-        """Tests the _list_GCS_blobs_with_retry initializes client before calling dataflux_core.fast_list.ListingController when multiprcessing start method is spawn."""
+        """Tests the _list_GCS_blobs_with_retry doesn't initializes client before calling dataflux_core.fast_list.ListingController when multiprcessing start method is set to spawn."""
 
-        # Arrange.
+        # Setup mocks for testing.
         mock_listing_controller = mock.Mock()
         mock_listing_controller.client = None
         mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        mock_dataflux_core.return_value = (mock_listing_controller)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -388,7 +390,7 @@ class ListingTestCase(unittest.TestCase):
 
     def test_init_without_perm(self):
         """Tests that the DataFluxIterableDataset returns permission error when create and delete permissions are missing."""
-        # Arrange.
+        # Setup client for testing.
         client = self.storage_client
         client._set_perm([], self.bucket_name)
 
@@ -402,15 +404,13 @@ class ListingTestCase(unittest.TestCase):
                 storage_client=client,
             )
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
     def test_init_with_perm(self, mock_dataflux_core):
         """Tests that the compose download is not disabled when create and delete permissions exists."""
-        # Arrange.
-        # Arrange.
-        mock_listing_controller = mock.Mock()
-        mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        # Setup mocks for testing.
+        self.initializeMockFastList(mock_dataflux_core)
         want_size = self.config.max_composite_object_size
 
         # Act.
@@ -429,14 +429,13 @@ class ListingTestCase(unittest.TestCase):
             f"got max_composite_object_size for compose download{ds.config.max_composite_object_size}, want {want_size}",
         )
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
     def test_getstate(self, mock_dataflux_core):
         """Tests that the dataset.__getitems__ method returns the list of the correct downloaded object content."""
-        # Arrange.
-        mock_listing_controller = mock.Mock()
-        mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        # Setup mocks for testing.
+        self.initializeMockFastList(mock_dataflux_core)
 
         # Act.
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
@@ -458,14 +457,13 @@ class ListingTestCase(unittest.TestCase):
             f"got dataflux_mapstyle_dataset params {states}, want {want_state}",
         )
 
-    @mock.patch("dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core")
+    @mock.patch(
+        "dataflux_pytorch.dataflux_mapstyle_dataset.dataflux_core.fast_list.ListingController"
+    )
     def test_setstate(self, mock_dataflux_core):
         """Tests that the dataset.__getitems__ method returns the list of the correct downloaded object content."""
-        # Arrange.
-        mock_listing_controller = mock.Mock()
-        mock_listing_controller.run.return_value = self.want_objects
-        mock_dataflux_core.fast_list.ListingController.return_value = (
-            mock_listing_controller)
+        # Setup mocks for testing.
+        self.initializeMockFastList(mock_dataflux_core)
 
         ds = dataflux_mapstyle_dataset.DataFluxMapStyleDataset(
             project_name=self.project_name,

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -49,7 +49,7 @@ class ListingTestCase(unittest.TestCase):
         self.storage_client = client
 
     def initializeMockFastList(self, mock_dataflux_core):
-        """ Test helper function to """
+        """Test helper function to setup mock for dataflux_core.fast_list.ListingController."""
         mock_listing_controller = mock.Mock()
         mock_listing_controller.run.return_value = self.want_objects
         mock_dataflux_core.return_value = (mock_listing_controller)


### PR DESCRIPTION
Move client creation from init to getitem and getitems. This way if a client is initialized  in DataFluxMapStyleDataset, it will not be used in fast-list. Only user defined client to be used in fast-list. 

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR