### PR TITLE
Move client initialization to getitem and getitems

### DIFF
--- a/dataflux_pytorch/dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/dataflux_mapstyle_dataset.py
@@ -138,8 +138,6 @@ class DataFluxMapStyleDataset(data.Dataset):
         self.bucket_name = bucket_name
         self.data_format_fn = data_format_fn
         self.config = config
-        if self.storage_client is None:
-            self.storage_client = storage.Client(project=self.project_name)
         # If composed download is enabled and a storage_client was provided,
         # check if the client has permissions to create and delete the
         # composed object.
@@ -165,6 +163,8 @@ class DataFluxMapStyleDataset(data.Dataset):
         return len(self.objects)
 
     def __getitem__(self, idx):
+        if self.storage_client is None:
+            self.storage_client = storage.Client(project=self.project_name)
         return self.data_format_fn(
             dataflux_core.download.download_single(
                 storage_client=self.storage_client,
@@ -174,6 +174,8 @@ class DataFluxMapStyleDataset(data.Dataset):
             ))
 
     def __getitems__(self, indices):
+        if self.storage_client is None:
+            self.storage_client = storage.Client(project=self.project_name)
         return [
             self.data_format_fn(bytes_content) for bytes_content in
             dataflux_core.download.dataflux_download_threaded(
@@ -203,6 +205,7 @@ class DataFluxMapStyleDataset(data.Dataset):
                     retry_config=self.config.list_retry_config,
                 )
                 # If the dataset was not initialized with an storage_client, ensure that we do not attach a client to the lister to avoid pickling errors (#58).
+                lister.client = self.storage_client
                 listed_objects = lister.run()
 
             except Exception as e:

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -357,7 +357,6 @@ class ListingTestCase(unittest.TestCase):
         ds[want_idx]
 
         # Assert.
-        # Assert.
         self.assertIsNotNone(ds.storage_client,
                              "storage_client is not constructed on getitem.")
 

--- a/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
+++ b/dataflux_pytorch/tests/test_dataflux_mapstyle_dataset.py
@@ -144,7 +144,7 @@ class ListingTestCase(unittest.TestCase):
         )
 
         # Assert.
-        # Ensure that client is not constructed  in init when not passes by the user.
+        # Ensure that client is not constructed in init when not passed by the user.
         self.assertIsNone(
             ds.storage_client,
             "storage_client was unexpectedly constructed on init.")


### PR DESCRIPTION
Move client creation from init to getitem and getitems. This way if a client is initialized in DataFluxMapStyleDataset, it will not be used in fast-list. Only user defined client to be used in fast-list.

- [ ] Tests pass
- [ ] Appropriate changes to documentation are included in the PR