### PR TITLE
Remove model and path arguments from FSDP strategy constructors

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/multinode/train.py
@@ -5,15 +5,16 @@ import time
 
 import torch
 import torch.distributed
-from demo.lightning.checkpoint.multinode.strategies import (
-    DatafluxFSDPStrategy, FSSpecFSDPStrategy, LoadFromBootDiskFSDP)
-from demo.lightning.checkpoint.multinode.train import (DemoTransformer,
-                                                       init_processes)
 from google.cloud import storage
 from lightning import Trainer
 from lightning.pytorch.demos import WikiText2
 from lightning.pytorch.strategies import FSDPStrategy
 from torch.utils.data import DataLoader
+
+from demo.lightning.checkpoint.multinode.strategies import (
+    DatafluxFSDPStrategy, FSSpecFSDPStrategy, LoadFromBootDiskFSDP)
+from demo.lightning.checkpoint.multinode.train import (DemoTransformer,
+                                                       init_processes)
 
 DF_FSDP_STRATEGY = "dataflux_fsdp"
 FSSPEC_FSDP_STRATEGY = "fsspec_fsdp"
@@ -51,28 +52,23 @@ def validate(args):
         )
 
 
-def get_strategy(args, project, model, ckpt_dir_path):
+def get_strategy(args, project):
     strategy = None
     if args.strategy == DF_FSDP_STRATEGY:
         print("Using DatafluxFSDPStrategy")
         strategy = DatafluxFSDPStrategy(
-            path=ckpt_dir_path,
             project_name=project,
             storage_client=None,
-            model=model,
             state_dict_type="sharded",
             use_orig_params=False,
         )
     elif args.strategy == FSSPEC_FSDP_STRATEGY:
         print("Using FSSpecFSDPStrategy")
-        strategy = FSSpecFSDPStrategy(path=ckpt_dir_path,
-                                      model=model,
-                                      state_dict_type="sharded",
+        strategy = FSSpecFSDPStrategy(state_dict_type="sharded",
                                       use_orig_params=False)
     elif args.strategy == FSDP_STRATEGY and args.load_only:
         print("Using CustomFSDPStrategy.")
-        strategy = LoadFromBootDiskFSDP(ckpt_path=ckpt_dir_path,
-                                        project_name=project,
+        strategy = LoadFromBootDiskFSDP(project_name=project,
                                         state_dict_type="sharded",
                                         use_orig_params=False)
     elif (args.strategy == FSDP_STRATEGY
@@ -123,7 +119,7 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
 
     model = DemoTransformer(vocab_size=dataset.vocab_size,
                             nlayers=int(os.environ.get("NUM_LAYERS", 10)))
-    strategy = get_strategy(args, os.getenv("PROJECT"), model, ckpt_dir_path)
+    strategy = get_strategy(args, os.getenv("PROJECT"))
     num_save_calls = int(os.environ.get("NUM_SAVE_CALLS", 3))
     num_nodes = int(os.environ.get("NUM_NODES", 1))
 
@@ -165,8 +161,7 @@ def main(ckpt_dir_path: str, ckpt_restore_path: str = ""):
         model = DemoTransformer(vocab_size=dataset.vocab_size,
                                 nlayers=int(os.environ.get("NUM_LAYERS", 10)))
         new_ckpt_dir_path = os.path.join(ckpt_restore_path, f'ckpt_{i}.ckpt/')
-        strategy = get_strategy(args, os.getenv("PROJECT"), model,
-                                new_ckpt_dir_path)
+        strategy = get_strategy(args, os.getenv("PROJECT"))
         trainer = Trainer(
             enable_checkpointing=False,
             logger=False,

--- a/dataflux_pytorch/lightning/gcs_filesystem.py
+++ b/dataflux_pytorch/lightning/gcs_filesystem.py
@@ -6,10 +6,11 @@ from typing import Generator, Optional, Union
 
 import torch.distributed as dist
 from dataflux_core import user_agent
-from dataflux_pytorch.dataflux_checkpoint import DatafluxCheckpointBuffer
-from dataflux_pytorch.lightning.path_utils import parse_gcs_path
 from google.cloud import storage
 from torch.distributed.checkpoint import FileSystemReader, FileSystemWriter
+
+from dataflux_pytorch.dataflux_checkpoint import DatafluxCheckpointBuffer
+from dataflux_pytorch.lightning.path_utils import parse_gcs_path
 
 
 class GCSFileSystem():
@@ -108,7 +109,9 @@ class GCSDistributedWriter(FileSystemWriter):
                  debug: Optional[bool] = False,
                  **kwargs):
         super().__init__(path, **kwargs)
-        self.fs = GCSFileSystem(project_name, storage_client, debug)
+        self.fs = GCSFileSystem(project_name=project_name,
+                                storage_client=storage_client,
+                                debug=debug)
         self.sync_files = False
 
 
@@ -121,4 +124,6 @@ class GCSDistributedReader(FileSystemReader):
                  debug: Optional[bool] = False,
                  **kwargs):
         super().__init__(path, **kwargs)
-        self.fs = GCSFileSystem(project_name, storage_client, debug)
+        self.fs = GCSFileSystem(project_name=project_name,
+                                storage_client=storage_client,
+                                debug=debug)

--- a/demo/lightning/checkpoint/multinode/strategies.py
+++ b/demo/lightning/checkpoint/multinode/strategies.py
@@ -5,9 +5,6 @@ from typing import Generator
 import gcsfs
 import torch
 from dataflux_core import user_agent
-from dataflux_pytorch.lightning import DatafluxLightningCheckpoint
-from dataflux_pytorch.lightning.gcs_filesystem import (GCSDistributedReader,
-                                                       GCSDistributedWriter)
 from google.cloud import storage
 from lightning.pytorch.strategies import FSDPStrategy
 from lightning.pytorch.strategies.fsdp import _METADATA_FILENAME
@@ -16,6 +13,10 @@ from torch.distributed.checkpoint import _fsspec_filesystem as FF
 from torch.distributed.checkpoint import load, save
 from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
 from torch.nn import Module
+
+from dataflux_pytorch.lightning import DatafluxLightningCheckpoint
+from dataflux_pytorch.lightning.gcs_filesystem import (GCSDistributedReader,
+                                                       GCSDistributedWriter)
 
 
 def save_checkpoint_helper(rank, checkpoint, path, checkpoint_io, writer):
@@ -33,13 +34,10 @@ def save_checkpoint_helper(rank, checkpoint, path, checkpoint_io, writer):
 
 class DatafluxFSDPStrategy(FSDPStrategy):
 
-    def __init__(self, path, project_name, storage_client, model, **kwargs):
+    def __init__(self, project_name, storage_client, **kwargs):
         super().__init__(**kwargs)
-        self.writer = GCSDistributedWriter(path, project_name, storage_client)
-        self.reader = GCSDistributedReader(path, project_name, storage_client)
         self.checkpoint_io = DatafluxLightningCheckpoint(
             project_name, storage_client)
-        self.model = model
         self.storage_client = storage.Client(project=project_name)
         user_agent.add_dataflux_user_agent(self.storage_client)
 
@@ -54,8 +52,10 @@ class DatafluxFSDPStrategy(FSDPStrategy):
                     `CheckpointIO`.")
 
         path = Path(self.broadcast(filepath))
+        writer = GCSDistributedWriter(path, self.storage_client.project,
+                                      self.storage_client)
         save_checkpoint_helper(self.global_rank, checkpoint, path,
-                               self.checkpoint_io, self.writer)
+                               self.checkpoint_io, writer)
 
     def get_sharded_state_dict_context(
             self, module: Module) -> Generator[None, None, None]:
@@ -88,9 +88,12 @@ class DatafluxFSDPStrategy(FSDPStrategy):
 
         state_dict_ctx = self.get_sharded_state_dict_context(self.model)
 
+        reader = GCSDistributedReader(path, self.storage_client.project,
+                                      self.storage_client)
+
         with state_dict_ctx:
             module_state = {"model": self.model.state_dict()}
-            load(module_state, self.reader)
+            load(module_state, reader)
             self.model.load_state_dict(
                 module_state["model"],
                 strict=self.lightning_module.strict_loading)
@@ -102,7 +105,7 @@ class DatafluxFSDPStrategy(FSDPStrategy):
                     optim_state = load_sharded_optimizer_state_dict(
                         model_state_dict=module_state["model"],
                         optimizer_key=optim_key,
-                        storage_reader=self.reader,
+                        storage_reader=reader,
                     )
                     flattened_osd = FSDP.optim_state_dict_to_load(
                         optim_state_dict=optim_state[optim_key],
@@ -114,20 +117,16 @@ class DatafluxFSDPStrategy(FSDPStrategy):
         # Load metadata (anything not a module or optimizer)
         new_path = path / _METADATA_FILENAME
         metadata = None
-        with self.reader.fs.create_stream(path=new_path,
-                                          mode='rb') as metadata_file:
+        with reader.fs.create_stream(path=new_path,
+                                     mode='rb') as metadata_file:
             metadata = torch.load(metadata_file)
         return metadata
 
 
 class FSSpecFSDPStrategy(FSDPStrategy):
 
-    def __init__(self, path, model, **kwargs):
+    def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.model = model
-        self.path = path
-        self.reader = FF.FsspecReader(path)
-        self.writer = FF.FsspecWriter(self.path, sync_files=False)
         self.bucket = gcsfs.GCSFileSystem()
 
     def save_checkpoint(self,
@@ -141,6 +140,7 @@ class FSSpecFSDPStrategy(FSDPStrategy):
 
         # broadcast the path from rank 0 to ensure all the states are loaded from a common path
         self.broadcast(filepath)
+        writer = FF.FsspecWriter(filepath, sync_files=False)
 
         converted_state = {"model": checkpoint.pop("state_dict")}
         converted_state.update({
@@ -148,9 +148,7 @@ class FSSpecFSDPStrategy(FSDPStrategy):
             for idx, optim_state in enumerate(
                 checkpoint.pop("optimizer_states", []))
         })
-        save(converted_state,
-             checkpoint_id=filepath,
-             storage_writer=self.writer)
+        save(converted_state, checkpoint_id=filepath, storage_writer=writer)
 
         with self.bucket.open(os.path.join(filepath, _METADATA_FILENAME),
                               'wb') as f:
@@ -186,9 +184,11 @@ class FSSpecFSDPStrategy(FSDPStrategy):
 
         state_dict_ctx = self.get_sharded_state_dict_context(self.model)
 
+        reader = FF.FsspecReader(checkpoint_path)
+
         with state_dict_ctx:
             module_state = {"model": self.model.state_dict()}
-            load(module_state, self.reader)
+            load(module_state, reader)
             self.model.load_state_dict(
                 module_state["model"],
                 strict=self.lightning_module.strict_loading)
@@ -200,7 +200,7 @@ class FSSpecFSDPStrategy(FSDPStrategy):
                     optim_state = load_sharded_optimizer_state_dict(
                         model_state_dict=module_state["model"],
                         optimizer_key=optim_key,
-                        storage_reader=self.reader,
+                        storage_reader=reader,
                     )
                     flattened_osd = FSDP.optim_state_dict_to_load(
                         optim_state_dict=optim_state[optim_key],
@@ -212,8 +212,8 @@ class FSSpecFSDPStrategy(FSDPStrategy):
         # Load metadata (anything not a module or optimizer)
         new_path = os.path.join(checkpoint_path, _METADATA_FILENAME)
         metadata = None
-        with self.reader.fs.create_stream(path=new_path,
-                                          mode='rb') as metadata_file:
+        with reader.fs.create_stream(path=new_path,
+                                     mode='rb') as metadata_file:
             metadata = torch.load(metadata_file)
         return metadata
 
@@ -237,9 +237,9 @@ class LoadFromBootDiskFSDP(FSDPStrategy):
 
     """
 
-    def __init__(self, ckpt_path, project_name, **kwargs):
+    def __init__(self, project_name, **kwargs):
         super().__init__(**kwargs)
-        self.writer = GCSDistributedWriter(ckpt_path, project_name)
+        self.project_name = project_name
         self.checkpoint_io = DatafluxLightningCheckpoint(project_name)
 
     def save_checkpoint(self,
@@ -253,5 +253,6 @@ class LoadFromBootDiskFSDP(FSDPStrategy):
                     `CheckpointIO`.")
 
         path = Path(self.broadcast(filepath))
+        writer = GCSDistributedWriter(path, self.project_name)
         save_checkpoint_helper(self.global_rank, checkpoint, path,
-                               self.checkpoint_io, self.writer)
+                               self.checkpoint_io, writer)

--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -85,10 +85,8 @@ def main(project: str,
                       max_steps=max_steps_save,
                       accelerator=accelerator,
                       strategy=DatafluxFSDPStrategy(
-                          path=ckpt_dir_path,
                           project_name=project,
                           storage_client=None,
-                          model=model,
                           state_dict_type="sharded",
                       ),
                       num_nodes=int(os.environ.get("WORLD_SIZE", 5)))
@@ -108,10 +106,8 @@ def main(project: str,
                       max_steps=max_steps_restore,
                       accelerator=accelerator,
                       strategy=DatafluxFSDPStrategy(
-                          path=ckpt_restore_path,
                           project_name=project,
                           storage_client=None,
-                          model=model,
                           state_dict_type="sharded",
                       ),
                       num_nodes=int(os.environ.get("WORLD_SIZE", 5)))


### PR DESCRIPTION
This makes the constructor signature of our FSDP strategies more consistent with the base one, and ensures that the strategies can handle multiple different paths at runtime. `self.model` on the strategy is still set by the Lightning trainer when calling trainer.fit. 