### PR TITLE
Refactor DemoTransformer model to match Lightning demo

### DIFF
--- a/demo/lightning/checkpoint/multinode/train.py
+++ b/demo/lightning/checkpoint/multinode/train.py
@@ -128,7 +128,22 @@ class DemoTransformer(LightningTransformer):
     ) -> None:
         super().__init__()
         self.optimizer = optimizer
-        self.model = Transformer(vocab_size=vocab_size, nlayers=nlayers)
+        self.model = None
+        self.vocab_size = vocab_size
+        self.nlayers = nlayers
+
+    # Initialize the model here to allow it to be initialized on the GPU; see
+    # https://lightning.ai/docs/pytorch/stable/advanced/model_parallel/fsdp.html#speed-up-model-initialization
+    def configure_model(self):
+        if self.model is not None:
+            return
+        # Use the nhid, ninp, and nhead parameters from the guide linked above.
+        # This means that 1B parameters corresponds to 32 layers.
+        self.model = Transformer(vocab_size=self.vocab_size,
+                                 nlayers=self.nlayers,
+                                 nhid=4096,
+                                 ninp=1024,
+                                 nhead=64)
 
     def configure_optimizers(self) -> torch.optim.Optimizer:
         # Use self.trainer.model.parameters so that we can set


### PR DESCRIPTION
This changes the structure of the model to match the Lightning FSDP demo, making it more realistic and therefore making it perform better.

Now on a machine with 4 x NVIDIA V100 (1B parameters / 32 layers, creates ~4GB checkpoint in total):

Dataflux:
##################################
Average time to save one checkpoint: 6.372414588928223 seconds
Average time to load one checkpoint: 20.229445457458496 seconds
##################################

Fsspec:
##################################
Average time to save one checkpoint: 18.570948839187622 seconds
Average time to load one checkpoint: 73.39956045150757 seconds
##################################

I also verified that FSDP is sharding the model appropriately, since I can run this when using 4 GPUs but hit CUDA OOM when running on 1 GPU