### PR TITLE
Reference const, not value

### DIFF
--- a/dataflux_pytorch/benchmark/checkpointing/singlenode/train.py
+++ b/dataflux_pytorch/benchmark/checkpointing/singlenode/train.py
@@ -194,7 +194,7 @@ def main():
           str((end - start) / args.steps) + " seconds")
 
     # If using async, call finalize to shut down the threadpool executor.
-    if args.checkpoint == 'asynccheckpointio':
+    if args.checkpoint == ASYNC_DF_LIGHTNING:
         ckpt.finalize()
 
     # Measure load checkpoint.


### PR DESCRIPTION
Quick fix for recent CI failure.

Make sure we're referencing the const, not the value when checking choice args.