### PR TITLE
Add demo.image_segmentation.model

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     packages=[
         "dataflux_core", "dataflux_pytorch", "dataflux_pytorch.lightning",
         "dataflux_pytorch.multipart_upload", "demo.lightning.text_based",
-        "demo.lightning.checkpoint.multinode","demo.image_segmentation"
+        "demo.lightning.checkpoint.multinode","demo.image_segmentation","demo.image_segmentation.model"
     ],
     package_dir={"dataflux_core": "dataflux_client_python/dataflux_core"},
     install_requires=dependencies,


### PR DESCRIPTION
Add demo.image_segmentation.model to setup.py as a quick fix for 'ModuleNotFoundError' in lightning image-segmentation benchmark. 
Verified that the fix works with rest of the continuous bench tests. 

Long term fix would be to remove demo/image-segmentation module and use python command with "-m". 